### PR TITLE
Fix a bug in the wrong way loss function regarding the correct usage of the arctan2 function

### DIFF
--- a/torchdrivesim/lanelet2.py
+++ b/torchdrivesim/lanelet2.py
@@ -85,8 +85,11 @@ def find_lanelet_directions(lanelet_map: LaneletMap, x: float, y: float, tags_to
     directions = []
     for distance, lanelet in all_selected_lanelets:
         centerline = lanelet.centerline
-        if len(centerline) < 2 or any([lanelet_attr in lanelet.attributes for lanelet_attr in tags_to_exclude]):
+        if len(centerline) < 2:
             continue
+        if any([lanelet_attr in lanelet.attributes for lanelet_attr in tags_to_exclude]):
+            directions = []
+            break
         direction = find_direction(centerline, location3d)
         directions.append(direction)
     return directions

--- a/torchdrivesim/lanelet2.py
+++ b/torchdrivesim/lanelet2.py
@@ -126,7 +126,7 @@ def find_direction(linestring, location3d) -> float:
         point_a, point_b = linestring[second_closest_point_idx], linestring[closest_point_idx]
     else:
         point_b, point_a = linestring[second_closest_point_idx], linestring[closest_point_idx]
-    direction = np.arctan2(point_b.x - point_a.x, point_b.y - point_a.y)
+    direction = np.arctan2(point_b.y - point_a.y, point_b.x - point_a.x)
 
     return direction
 


### PR DESCRIPTION
The function [`find_direction()`](https://github.com/inverted-ai/torchdrivesim/blob/master/torchdrivesim/lanelet2.py#L95) has a bug when calling the `arctan2` operation. The correct usage is `arctan2(y, x)` and not `arctan2(x, y)`. This PR fixes this bug.

Furthermore, I went ahead and modified the function https://github.com/inverted-ai/torchdrivesim/blob/76f7d10f50e884d55d3b6df9f249bc3cd163dca4/torchdrivesim/lanelet2.py#L63 for yielding the desired behavior when computing the wrong way loss for excluded lanelets. Typically, when an agent is contained in an excluded lanelet such as a parking spot, we want the wrong way loss to be zero since these lanelets are agnostic to the direction the agent is facing. Currently, the way it works is by just avoiding returning a direction if the agent touches these lanelets but there is no rule to enforce setting the loss for that agent to be zero if any of the found lanelets has an exclusion tag. My solution to correct this is rather simple without having to change too many things but it's not very elegant. If you have a better suggestion let me know.
