### PR TITLE
Add the option to pass to simulator waypoints per agent and render them

### DIFF
--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -5,6 +5,7 @@ import torch
 from torchdrivesim.simulator import TorchDriveConfig, Simulator
 from torchdrivesim.kinematic import KinematicBicycle
 from torchdrivesim.mesh import BirdviewMesh
+from torchdrivesim.goals import WaypointGoal
 from tests import device
 
 
@@ -72,8 +73,9 @@ class TestBaseSimulator:
         projector = lanelet2.projection.UtmProjector(lanelet2.io.Origin(*origin))
         lanelet_map = lanelet2.io.load(cls.lanelet_map_path, projector)
         lanelet_map = [lanelet_map for _ in range(cls.data_batch_size)]
+        waypoint_goals = WaypointGoal(dict(vehicle=torch.zeros_like(cls.mock_agent_state[..., :2])[:, :, None, None, :]))
         return Simulator(road_mesh, kinematic_model, agent_size,
-                         initial_present_mask, cls.config, lanelet_map=lanelet_map).to(device)
+                         initial_present_mask, cls.config, lanelet_map=lanelet_map, waypoint_goals=waypoint_goals).to(device)
 
     @staticmethod
     def get_tensor(item):

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -10,4 +10,6 @@ def test_render_agents(cfg: RendererConfig):
     renderer = renderer_from_config(cfg, batch_size=batch_size).to(device)
     agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
     agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
-    renderer.render_frame(agents_states, agents_attributes)
+    waypoints = agents_attributes['vehicle'][..., :3]
+    waypoints_mask = torch.ones(waypoints.shape[:-1], device=waypoints.device, dtype=torch.bool)
+    renderer.render_frame(agents_states, agents_attributes, waypoints=waypoints, waypoints_rendering_mask=waypoints_mask)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -10,6 +10,6 @@ def test_render_agents(cfg: RendererConfig):
     renderer = renderer_from_config(cfg, batch_size=batch_size).to(device)
     agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
     agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
-    waypoints = agents_attributes['vehicle'][..., :3]
+    waypoints = torch.zeros(batch_size, 3, 2, 3).to(device)
     waypoints_mask = torch.ones(waypoints.shape[:-1], device=waypoints.device, dtype=torch.bool)
     renderer.render_frame(agents_states, agents_attributes, waypoints=waypoints, waypoints_rendering_mask=waypoints_mask)

--- a/torchdrivesim/goals.py
+++ b/torchdrivesim/goals.py
@@ -1,0 +1,220 @@
+"""
+Definitions of goal conditions. Currently, we support waypoint conditions.
+"""
+import copy
+import dataclasses
+from typing import List, Optional, Union, Dict
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+TensorPerAgentType = Union[Tensor, Dict[str, Tensor]]
+
+
+class WaypointGoal:
+    """
+    Waypoints can be given either per agent type or directly as tensors. The waypoint tensor can contain `M` waypoints
+    for each collection of `N` waypoints that progressively get enabled. The provided mask should indicated which waypoints
+    are padding elements. A waypoint is marked as succesful when the agent state reaches the center of the waypoint
+    within some distance.
+
+    Args:
+        waypoints: a functor of BxAxNxMx2 waypoint tensors [x, y]
+        mask: a functor of BxAxNxM boolean tensor indicating whether a given waypoint element is present and not a padding.
+    """
+    def __init__(self, waypoints: TensorPerAgentType, mask: Optional[TensorPerAgentType] = None):
+        self.waypoints = waypoints
+        self.mask = mask if mask is not None else self._default_mask()
+        if isinstance(self.waypoints, dict):
+            self.max_goal_idx = max([v.shape[2] for v in self.waypoints.values()])
+        else:
+            self.max_goal_idx = self.waypoints.shape[2]
+        self.state = self._default_state()  # BxAx1
+
+
+    def _default_mask(self) -> Tensor:
+        if isinstance(self.waypoints, dict):
+            return {k: torch.ones(*v.shape[:-1], dtype=torch.bool, device=v.device) for k,v in self.waypoints.items()}
+        else:
+            return torch.ones(*self.waypoints.shape[:-1], dtype=torch.bool, device=self.waypoints.device)
+
+    def _default_state(self) -> Tensor:
+        if isinstance(self.waypoints, dict):
+            return {k: torch.zeros(*v.shape[:2] + (1, ), dtype=torch.long, device=v.device) for k,v in self.waypoints.items()}
+        else:
+            return torch.zeros(*self.waypoints.shape[:2] + (1, ), dtype=torch.long, device=self.waypoints.device)
+
+    def get_masks(self):
+        """
+        Returns the waypoint mask according to the current state value.
+        """
+        if isinstance(self.waypoints, dict):
+            return {k: torch.gather(v, 2, self.state[k][..., None].expand(-1, -1, -1, *v.shape[3:])).squeeze(2)
+                    for k,v in self.mask.items()}
+        else:
+            return torch.gather(self.mask, 2, self.state[..., None].expand(-1, -1, -1, *self.mask.shape[3:])).squeeze(2)
+
+    def get_waypoints(self):
+        """
+        Returns the waypoints according to the current state value.
+        """
+        if isinstance(self.waypoints, dict):
+            return {k: torch.gather(v, 2, self.state[k][..., None, None].expand(-1, -1, -1, *v.shape[3:])).squeeze(2)
+                    for k,v in self.waypoints.items()}
+        else:
+            return torch.gather(self.waypoints, 2, self.state[..., None, None]\
+                .expand(-1, -1, -1, *self.waypoints.shape[3:])).squeeze(2)
+
+    def copy(self):
+        """
+        Duplicates this object, allowing for independent subsequent execution.
+        """
+        other = self.__class__(
+            waypoints=copy.deepcopy(self.waypoints), mask=copy.deepcopy(self.mask),
+        )
+        other.state = copy.deepcopy(self.state)
+        return other
+
+    def to(self, device: torch.device):
+        """
+        Modifies the object in-place, putting all tensors on the device provided.
+        """
+        if isinstance(self.waypoints, dict):
+            self.waypoints = {k: v.to(device) for k, v in self.waypoints.items()}
+        else:
+            self.waypoints = self.waypoints.to(device)
+
+        if isinstance(self.mask, dict):
+            self.mask = {k: v.to(device) for k, v in self.mask.items()}
+        else:
+            self.mask = self.mask.to(device)
+
+        if isinstance(self.state, dict):
+            self.state = {k: v.to(device) for k, v in self.state.items()}
+        else:
+            self.state = self.state.to(device)
+        return self
+
+    def extend(self, n: int, in_place: bool = True):
+        """
+        Multiplies the first batch dimension by the given number.
+        This is equivalent to introducing extra batch dimension on the right and then flattening.
+        """
+        if not in_place:
+            other = self.copy()
+            other.extend(n, in_place=True)
+            return other
+
+        enlarge = lambda x: x.unsqueeze(1).expand(
+            (x.shape[0], n) + x.shape[1:]
+        ).reshape((n * x.shape[0],) + x.shape[1:])
+        if isinstance(self.waypoints, dict):
+            self.waypoints = {k: enlarge(v) for k, v in self.waypoints.items()}
+        else:
+            self.waypoints = enlarge(self.waypoints)
+
+        if isinstance(self.mask, dict):
+            self.mask = {k: enlarge(v) for k, v in self.mask.items()}
+        else:
+            self.mask = enlarge(self.mask)
+
+        if isinstance(self.state, dict):
+            self.state = {k: enlarge(v) for k, v in self.state.items()}
+        else:
+            self.state = enlarge(self.state)
+        return self
+
+    def select_batch_elements(self, idx: Tensor, in_place: bool = True):
+        """
+        Picks selected elements of the batch.
+        The input is a tensor of indices into the batch dimension.
+        """
+        if not in_place:
+            other = self.copy()
+            other.select_batch_elements(idx, in_place=True)
+            return other
+
+        if isinstance(self.waypoints, dict):
+            self.waypoints = {k: v[idx] for k, v in self.waypoints.items()}
+        else:
+            self.waypoints = self.waypoints[idx]
+
+        if isinstance(self.mask, dict):
+            self.mask = {k: v[idx] for k, v in self.mask.items()}
+        else:
+            self.mask = self.mask[idx]
+
+        if isinstance(self.state, dict):
+            self.state = {k: v[idx] for k, v in self.state.items()}
+        else:
+            self.state = self.state[idx]
+        return self
+
+    def step(self, agent_states: TensorPerAgentType, time: int, threshold = 2.0) -> None:
+        """
+        Advances the state of the waypoints.
+        """
+        if isinstance(agent_states, dict):
+            assert isinstance(self.waypoints, dict)
+            assert sum([a.shape[1] for a in agent_states.values()]) == sum(w.shape[1] for w in self.waypoints.values())
+            assert list(agent_states.keys()) == list(self.waypoints.keys())
+            waypoints = self.get_waypoints()
+            masks = self.get_masks()
+            for agent_type, agent_state in agent_states.items():
+                agent_overlap = self._agent_waypoint_overlap(agent_state[..., :2], waypoints[agent_type], threshold=threshold)
+                agent_overlap = agent_overlap.any(dim=-1, keepdim=True).expand_as(agent_overlap)
+                agent_overlap = torch.where(masks[agent_type], agent_overlap, True)
+                self.mask[agent_type] = self._update_mask(self.state[agent_type], self.mask[agent_type],
+                                                          agent_overlap.logical_not())
+                self.state[agent_type] = self._advance_state(self.state[agent_type], agent_overlap)
+        else:
+            assert torch.is_tensor(self.waypoints)
+            assert agent_states.shape[1] == self.waypoints.shape[1]
+            waypoints = self.get_waypoints()
+            masks = self.get_masks()
+            agent_overlap = self._agent_waypoint_overlap(agent_states[..., :2], waypoints, threshold=threshold)
+            agent_overlap = agent_overlap.any(dim=-1, keepdim=True).expand_as(agent_overlap)
+            agent_overlap = torch.where(masks, agent_overlap, True)
+            self.mask = self._update_mask(self.state, self.mask, agent_overlap.logical_not())
+            self.state = self._advance_state(self.state, agent_overlap)
+
+    def _update_mask(self, state, mask, new_mask):
+        """
+        Helper function to update the global masks on the current state with the `new_mask` values.
+
+        Args:
+            state: BxAx1 int tensor
+            mask: BxAxNxM boolean tensor
+            new_mask: BxAxM boolean tensor
+        Returns:
+            BxAxNxM boolean tensor updated with the `new_mask` values
+        """
+        return torch.scatter(mask, 2, state[..., None].expand(-1, -1, -1, mask.shape[-1]), new_mask.unsqueeze(2))
+
+    def _advance_state(self, state, agent_overlap):
+        """
+        Helper function to advance the state when agents overlap with waypoints.
+
+        Args:
+            state: BxAx1 int tensor
+            agent_overlap: BxAxM boolean tensor
+        Returns:
+            BxAxM boolean tensor indicating the state of the waypoints
+        """
+        return torch.clamp(state + agent_overlap.any(dim=-1, keepdim=True), min=0, max=self.max_goal_idx-1)
+
+    def _agent_waypoint_overlap(self, agent_states: Tensor, waypoints: Tensor, threshold = 2.0) -> Tensor:
+        """
+        Helper function to detect if agent states overlap with the current waypoints.
+
+        Args:
+            agent_states: BxAx2 tensor of agents states - x,y
+            waypoints: BxAxMx2 tensor of waypoint
+        Returns:
+            BxAxM boolean tensor indicating which agents overlap with the waypoints
+        """
+        agent_states = agent_states[..., None, :].expand_as(waypoints)
+        dist = (((agent_states[..., 0] - waypoints[..., 0])**2) + ((agent_states[..., 1] - waypoints[..., 1])**2))**0.5
+        return dist <= threshold

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -21,7 +21,7 @@ import torch
 from torch import Tensor
 from torch.nn.utils.rnn import pad_sequence
 
-from torchdrivesim.utils import is_inside_polygon, merge_dicts
+from torchdrivesim.utils import is_inside_polygon, merge_dicts, rotate
 
 logger = logging.getLogger(__name__)
 
@@ -799,3 +799,35 @@ def generate_annulus_polygon_mesh(polygon: Tensor, scaling_factor: float, origin
     if category is not None:
         mesh = rendering_mesh(mesh, category=category)
     return mesh
+
+
+def generate_disc_mesh(radius: Optional[float] = 2, num_triangles: Optional[int] = 10,
+                       device: Optional[str] = 'cpu') -> Tuple[Tensor, Tensor]:
+    """
+    For a given radius, it will create a disc mesh using `num_triangles` triangles.
+
+    Args:
+        radius: float defining the radius of the disc
+        num_triangles: int defining the number of triangles to be used for creating the disc
+        device: the device to be used for the generated PyTorch tensors
+    """
+    angleStep = torch.deg2rad(torch.tensor([[360 / num_triangles]], dtype=torch.float32, device=device))
+
+    vertices = [
+        torch.zeros(1, 2, dtype=torch.float32, device=device),
+        torch.tensor([[radius, 0]], dtype=torch.float32, device=device),
+        rotate(torch.tensor([[radius, 0]], dtype=torch.float32, device=device), angleStep)
+    ]
+    faces = [
+        torch.tensor([[0, 1, 2]], dtype=torch.long, device=device)
+    ]
+
+    for i in range(num_triangles - 1):
+        if i == num_triangles - 2:
+            faces.append(torch.tensor([[0, len(vertices)-1, 1]], dtype=torch.long, device=device))
+        else:
+            faces.append(torch.tensor([[0, len(vertices)-1, len(vertices)]], dtype=torch.long, device=device))
+            vertices.append(rotate(vertices[-1], angleStep))
+    vertices = torch.cat(vertices, dim=0)
+    faces = torch.cat(faces, dim=0)
+    return vertices, faces

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -801,8 +801,7 @@ def generate_annulus_polygon_mesh(polygon: Tensor, scaling_factor: float, origin
     return mesh
 
 
-def generate_disc_mesh(radius: Optional[float] = 2, num_triangles: Optional[int] = 10,
-                       device: Optional[str] = 'cpu') -> Tuple[Tensor, Tensor]:
+def generate_disc_mesh(radius: float = 2, num_triangles: int = 10, device: str = 'cpu') -> Tuple[Tensor, Tensor]:
     """
     For a given radius, it will create a disc mesh using `num_triangles` triangles.
 

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -268,7 +268,7 @@ class BirdviewRenderer(abc.ABC):
             res: resolution HxW of the resulting image, currently only square resolutions are supported
             traffic_controls: traffic controls by type (traffic-light, yield, etc.)
             fov: Field of view in meters
-            waypoints: BxNcxMx3 tensor of `M` waypoints per camera (x,y,psi)
+            waypoints: BxNcxMx2 tensor of `M` waypoints per camera (x,y)
             waypoints_rendering_mask: BxNcxM tensor of `M` waypoint masks per camera,
                 indicating which waypoints should be rendered
 
@@ -482,7 +482,7 @@ class BirdviewRenderer(abc.ABC):
         disc_verts, disc_faces = generate_disc_mesh(device=waypoints.device, radius=radius, num_triangles=num_triangles)
         disc_verts = disc_verts[None, ...].expand(batch_size*n_cameras*n_waypoints, *disc_verts.shape)
         n_verts = disc_verts.shape[-2]
-        disc_verts = self.transform(disc_verts, waypoints.reshape(-1, 3))
+        disc_verts = self.transform(disc_verts, F.pad(waypoints, (0,1), value=0).reshape(-1, 3))
         disc_verts = disc_verts.reshape(batch_size*n_cameras, n_waypoints*disc_verts.shape[1], 2)
         disc_faces = disc_faces[None, None, ...].expand(batch_size*n_cameras, n_waypoints, *disc_faces.shape)
         disc_faces = disc_faces + n_verts*torch.arange(n_waypoints, device=disc_faces.device)[None, :, None, None]

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -268,7 +268,7 @@ class BirdviewRenderer(abc.ABC):
             res: resolution HxW of the resulting image, currently only square resolutions are supported
             traffic_controls: traffic controls by type (traffic-light, yield, etc.)
             fov: Field of view in meters
-            waypoints: BxNcx3 tensor of waypoints per camera
+            waypoints: BxNcx3 tensor of waypoints per camera (x,y,psi)
             waypoints_rendering_mask: BxNc tensor of waypoints mask per camera, indicating which waypoints should be rendered
 
         Returns:
@@ -471,7 +471,7 @@ class BirdviewRenderer(abc.ABC):
         Create a mesh of the given waypoints.
 
         Args:
-            waypoints: BxNcx3 tensor of waypoints per camera
+            waypoints: BxNcx3 tensor of waypoints per camera (x,y,psi)
         """
         batch_size, n_cameras = waypoints.shape[0], waypoints.shape[1]
         disc_verts, disc_faces = generate_disc_mesh(device=waypoints.device)

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -326,8 +326,6 @@ class BirdviewRenderer(abc.ABC):
             controls_mesh = self.make_traffic_controls_mesh(traffic_controls)
             meshes.append(controls_mesh)
 
-        mesh = static_mesh.concat(meshes)
-
         if waypoints is not None:
             if waypoints.shape[1] != n_cameras_per_batch:
                 raise ValueError((f"The given waypoints ({waypoints.shape[1]} do not match "
@@ -339,7 +337,9 @@ class BirdviewRenderer(abc.ABC):
                 waypoints_mesh = dataclasses.replace(
                     waypoints_mesh, faces=waypoints_faces
                 )
-            mesh = mesh.concat([mesh, waypoints_mesh])
+            meshes.append(waypoints_mesh)
+
+        mesh = static_mesh.concat(meshes)
 
         if res is None:
             res = self.res

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -469,8 +469,7 @@ class BirdviewRenderer(abc.ABC):
         # faces = faces.expand(batch_size, n_actors, 3)
         return BaseMesh(verts=verts, faces=faces)
 
-    def make_waypoint_mesh(self, waypoints: Tensor, radius: Optional[float] = 2.0,
-                           num_triangles: Optional[int] = 10) -> BirdviewMesh:
+    def make_waypoint_mesh(self, waypoints: Tensor, radius: float = 2.0, num_triangles: int = 10) -> BirdviewMesh:
         """
         Create a mesh of the given waypoints.
 

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -268,8 +268,9 @@ class BirdviewRenderer(abc.ABC):
             res: resolution HxW of the resulting image, currently only square resolutions are supported
             traffic_controls: traffic controls by type (traffic-light, yield, etc.)
             fov: Field of view in meters
-            waypoints: BxNcx3 tensor of waypoints per camera (x,y,psi)
-            waypoints_rendering_mask: BxNc tensor of waypoints mask per camera, indicating which waypoints should be rendered
+            waypoints: BxNcxMx3 tensor of `M` waypoints per camera (x,y,psi)
+            waypoints_rendering_mask: BxNcxM tensor of `M` waypoint masks per camera,
+                indicating which waypoints should be rendered
 
         Returns:
             tensor image of float RGB values in [0,255] range with shape shape (B*Nc)xAxCxHxW
@@ -330,10 +331,12 @@ class BirdviewRenderer(abc.ABC):
             if waypoints.shape[1] != n_cameras_per_batch:
                 raise ValueError((f"The given waypoints ({waypoints.shape[1]} do not match "
                     f"the number of cameras ({n_cameras_per_batch})."))
-            waypoints_mesh = self.make_waypoint_mesh(waypoints)
+            n_waypoints = waypoints.shape[-2]
+            waypoints_mesh = self.make_waypoint_mesh(waypoints, radius=2.0, num_triangles=10)
             if waypoints_rendering_mask is not None:
                 waypoints_faces = waypoints_mesh.faces
-                waypoints_faces = waypoints_faces * waypoints_rendering_mask.reshape(-1, 1, 1).expand_as(waypoints_faces)
+                waypoints_mask = waypoints_rendering_mask.reshape(-1, n_waypoints, 1, 1).expand(-1, -1, 10, 3)
+                waypoints_faces = waypoints_faces * waypoints_mask.reshape(-1, n_waypoints*10, 3)
                 waypoints_mesh = dataclasses.replace(
                     waypoints_mesh, faces=waypoints_faces
                 )
@@ -466,18 +469,25 @@ class BirdviewRenderer(abc.ABC):
         # faces = faces.expand(batch_size, n_actors, 3)
         return BaseMesh(verts=verts, faces=faces)
 
-    def make_waypoint_mesh(self, waypoints: Tensor) -> BirdviewMesh:
+    def make_waypoint_mesh(self, waypoints: Tensor, radius: Optional[float] = 2.0,
+                           num_triangles: Optional[int] = 10) -> BirdviewMesh:
         """
         Create a mesh of the given waypoints.
 
         Args:
-            waypoints: BxNcx3 tensor of waypoints per camera (x,y,psi)
+            waypoints: BxNcxMx3 tensor of `M` waypoints per camera (x,y,psi)
+            radius: float radius of the disc
+            num_triangles: int number of triangles used for the disc
         """
-        batch_size, n_cameras = waypoints.shape[0], waypoints.shape[1]
-        disc_verts, disc_faces = generate_disc_mesh(device=waypoints.device)
-        disc_verts = disc_verts[None, ...].expand(batch_size*n_cameras, *disc_verts.shape)
-        disc_faces = disc_faces[None, ...].expand(batch_size*n_cameras, *disc_faces.shape)
+        batch_size, n_cameras, n_waypoints = waypoints.shape[0], waypoints.shape[1], waypoints.shape[2]
+        disc_verts, disc_faces = generate_disc_mesh(device=waypoints.device, radius=radius, num_triangles=num_triangles)
+        disc_verts = disc_verts[None, ...].expand(batch_size*n_cameras*n_waypoints, *disc_verts.shape)
         disc_verts = self.transform(disc_verts, waypoints.reshape(-1, 3))
+        disc_verts = disc_verts.reshape(batch_size*n_cameras, n_waypoints*disc_verts.shape[1], 2)
+        disc_faces = disc_faces[None, None, ...].expand(batch_size*n_cameras, n_waypoints, *disc_faces.shape)
+        n_faces = disc_faces.shape[-2] + 1
+        disc_faces = disc_faces + n_faces*torch.arange(n_waypoints, device=disc_faces.device)[None, :, None, None]
+        disc_faces = disc_faces.flatten(1, 2)
         return rendering_mesh(BaseMesh(verts=disc_verts, faces=disc_faces), 'goal_waypoint')
 
 

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -481,11 +481,11 @@ class BirdviewRenderer(abc.ABC):
         batch_size, n_cameras, n_waypoints = waypoints.shape[0], waypoints.shape[1], waypoints.shape[2]
         disc_verts, disc_faces = generate_disc_mesh(device=waypoints.device, radius=radius, num_triangles=num_triangles)
         disc_verts = disc_verts[None, ...].expand(batch_size*n_cameras*n_waypoints, *disc_verts.shape)
+        n_verts = disc_verts.shape[-2]
         disc_verts = self.transform(disc_verts, waypoints.reshape(-1, 3))
         disc_verts = disc_verts.reshape(batch_size*n_cameras, n_waypoints*disc_verts.shape[1], 2)
         disc_faces = disc_faces[None, None, ...].expand(batch_size*n_cameras, n_waypoints, *disc_faces.shape)
-        n_faces = disc_faces.shape[-2] + 1
-        disc_faces = disc_faces + n_faces*torch.arange(n_waypoints, device=disc_faces.device)[None, :, None, None]
+        disc_faces = disc_faces + n_verts*torch.arange(n_waypoints, device=disc_faces.device)[None, :, None, None]
         disc_faces = disc_faces.flatten(1, 2)
         return rendering_mesh(BaseMesh(verts=disc_verts, faces=disc_faces), 'goal_waypoint')
 

--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -14,6 +14,7 @@ import torch
 from torch import Tensor
 from torch.nn.functional import pad
 
+from torchdrivesim.goals import WaypointGoal
 from torchdrivesim.kinematic import KinematicModel
 from torchdrivesim.lanelet2 import LaneletMap
 from torchdrivesim.mesh import generate_trajectory_mesh, BirdviewMesh
@@ -263,6 +264,20 @@ class SimulatorInterface(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def get_waypoints(self) -> TensorPerAgentType:
+        """
+        Returns a functor of BxAxMx2 tensors representing current agent waypoints.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_waypoints_mask(self) -> TensorPerAgentType:
+        """
+        Returns a functor of BxAxM boolean tensors representing current agent waypoints present mask.
+        """
+        pass
+
+    @abc.abstractmethod
     def step(self, agent_action: TensorPerAgentType) -> None:
         """
         Runs the simulation for one step with given agent actions.
@@ -308,7 +323,8 @@ class SimulatorInterface(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def render(self, camera_xy: Tensor, camera_psi: Tensor, res: Optional[Resolution] = None,
-               rendering_mask: Optional[TensorPerAgentType] = None, fov: Optional[float] = None) -> Tensor:
+               rendering_mask: Optional[TensorPerAgentType] = None, fov: Optional[float] = None,
+               waypoints: Optional[Tensor] = None, waypoints_rendering_mask: Optional[Tensor] = None) -> Tensor:
         """
         Renders the world from bird's eye view using cameras in given positions.
 
@@ -318,6 +334,9 @@ class SimulatorInterface(metaclass=abc.ABCMeta):
             res: desired image resolution (only square resolutions are supported; by default use value from config)
             rendering_mask: functor of BxNxA tensors, indicating which agents should be rendered each camera
             fov: the field of view of the resulting image in meters (by default use value from config)
+            waypoints: BxNxMx2 tensor of `M` waypoints per camera (x,y)
+            waypoints_rendering_mask: BxNxM tensor of `M` waypoint masks per camera,
+                indicating which waypoints should be rendered
         Returns:
              BxNxCxHxW tensor of resulting RGB images for each camera
         """
@@ -343,6 +362,15 @@ class SimulatorInterface(metaclass=abc.ABCMeta):
         agent_count_dict = dict(agent=agent_count) if singleton else agent_count
         camera_xy = torch.cat([s[0] for s in agent_pos_dict.values()], dim=-2)
         camera_psi = torch.cat([s[1] for s in agent_pos_dict.values()], dim=-2)
+        waypoints = self.get_waypoints()
+        if waypoints is not None:
+            waypoints_mask = self.get_waypoints_mask()
+            waypoints_dict = dict(agent=waypoints) if singleton else waypoints
+            waypoints_mask_dict = dict(agent=waypoints_mask) if singleton else waypoints_mask
+            waypoints = torch.cat(list(waypoints_dict.values()), dim=-3)
+            waypoints_mask = torch.cat(list(waypoints_mask_dict.values()), dim=-2)
+        else:
+            waypoints, waypoints_mask = None, None
         if not ego_rotate:
             camera_psi = torch.ones_like(camera_psi) * (np.pi / 2)
         # render birdview and split resulting tensor across agent types
@@ -363,7 +391,8 @@ class SimulatorInterface(metaclass=abc.ABCMeta):
                 torch.zeros(a_pos[0].shape[0], camera_xy.shape[1], 0).to(camera_xy.device),
                 agent_pos, agent_count, agent_rel_starting_idx)  # BxNcxA where Nc=A
 
-        bv = self.render(camera_xy, camera_psi, rendering_mask=rendering_mask, res=res, fov=fov)
+        bv = self.render(camera_xy, camera_psi, rendering_mask=rendering_mask, res=res, fov=fov,
+                         waypoints=waypoints, waypoints_rendering_mask=waypoints_mask)
         chunks = [0] + list(np.cumsum(list(agent_count_dict.values())))
         total_agents = chunks[-1]
         bv = bv.reshape((bv.shape[0] // total_agents, total_agents) + bv.shape[1:])
@@ -521,7 +550,8 @@ class Simulator(SimulatorInterface):
                  agent_size: Dict[str, Tensor], initial_present_mask: Dict[str, Tensor],
                  cfg: TorchDriveConfig, renderer: Optional[BirdviewRenderer] = None,
                  lanelet_map: Optional[List[Optional[LaneletMap]]] = None, recenter_offset: Optional[Tensor] = None,
-                 internal_time: int = 0, traffic_controls: Optional[Dict[str, BaseTrafficControl]] = None):
+                 internal_time: int = 0, traffic_controls: Optional[Dict[str, BaseTrafficControl]] = None,
+                 waypoint_goals: Optional[WaypointGoal] = None):
         self.road_mesh = road_mesh
         self.lanelet_map = lanelet_map
         self.recenter_offset = recenter_offset
@@ -548,6 +578,7 @@ class Simulator(SimulatorInterface):
             self.renderer = renderer
 
         self.traffic_controls = traffic_controls
+        self.waypoint_goals = waypoint_goals
 
         if cfg.left_handed_coordinates:
             def set_left_handed(kin):
@@ -585,6 +616,7 @@ class Simulator(SimulatorInterface):
 
         self.kinematic_model = self.agent_functor.to_device(self.kinematic_model, device)  # type: ignore
         self.traffic_controls = {k: v.to(device) for (k, v) in self.traffic_controls.items()} if self.traffic_controls is not None else None
+        self.waypoint_goals = self.waypoint_goals.to(device) if self.waypoint_goals is not None else None
         self.renderer = self.renderer.to(device)
 
         return self
@@ -595,7 +627,8 @@ class Simulator(SimulatorInterface):
             agent_size=self.agent_size, initial_present_mask=self.present_mask,
             cfg=self.cfg, renderer=self.renderer.copy(), lanelet_map=self.lanelet_map,
             recenter_offset=self.recenter_offset, internal_time=self.internal_time,
-            traffic_controls={k: v.copy() for k, v in self.traffic_controls.items()} if self.traffic_controls is not None else None
+            traffic_controls={k: v.copy() for k, v in self.traffic_controls.items()} if self.traffic_controls is not None else None,
+            waypoint_goals=self.waypoint_goals.copy() if self.waypoint_goals is not None else None
         )
         return other
 
@@ -623,6 +656,9 @@ class Simulator(SimulatorInterface):
         self.renderer = self.renderer.expand(n)
         if self.traffic_controls is not None:
             self.traffic_controls={k: v.extend(n) for k, v in self.traffic_controls.items()}
+
+        if self.waypoint_goals is not None:
+            self.waypoint_goals = self.waypoint_goals.extend(n)
 
         return self
 
@@ -657,6 +693,8 @@ class Simulator(SimulatorInterface):
         self.renderer = self.renderer.select_batch_elements(idx)
         if self.traffic_controls is not None:
             self.traffic_controls={k: v.select_batch_elements(idx) for k, v in self.traffic_controls.items()}
+        if self.waypoint_goals is not None:
+            self.waypoint_goals = self.waypoint_goals.select_batch_elements(idx)
         return self
 
     def validate_agent_types(self):
@@ -696,6 +734,12 @@ class Simulator(SimulatorInterface):
 
     def get_state(self):
         return self.across_agent_types(lambda kin: kin.get_state(), self.kinematic_model)
+
+    def get_waypoints(self):
+        return self.waypoint_goals.get_waypoints() if self.waypoint_goals is not None else None
+
+    def get_waypoints_mask(self):
+        return self.waypoint_goals.get_masks() if self.waypoint_goals is not None else None
 
     def compute_wrong_way(self):
         if self.lanelet_map is not None:
@@ -780,6 +824,8 @@ class Simulator(SimulatorInterface):
         if self.traffic_controls is not None:
             for traffic_control_type, traffic_control in self.traffic_controls.items():
                 traffic_control.step(self.internal_time)
+        if self.waypoint_goals is not None:
+            self.waypoint_goals.step(self.get_state(), self.internal_time)
 
     def set_state(self, agent_state, mask=None):
         if mask is None:
@@ -830,7 +876,8 @@ class Simulator(SimulatorInterface):
 
         return action
 
-    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None):
+    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None,
+               waypoints=None, waypoints_rendering_mask=None):
         camera_sc = torch.cat([torch.sin(camera_psi), torch.cos(camera_psi)], dim=-1)
         if len(camera_xy.shape) == 2:
             # Reshape from Bx2 to Bx1x2
@@ -845,6 +892,7 @@ class Simulator(SimulatorInterface):
         }
         return self.renderer.render_frame(
             self.get_state(), self.get_agent_size(), camera_xy, camera_sc, rendering_mask, res=res, fov=fov,
+            waypoints=waypoints, waypoints_rendering_mask=waypoints_rendering_mask,
             traffic_controls={k: v.copy() for k, v in self.traffic_controls.items()}
                 if self.traffic_controls is not None else None
         )
@@ -1003,6 +1051,12 @@ class SimulatorWrapper(SimulatorInterface):
     def get_present_mask(self):
         return self.inner_simulator.get_present_mask()
 
+    def get_waypoints(self):
+        return self.inner_simulator.get_waypoints()
+
+    def get_waypoints_mask(self):
+        return self.inner_simulator.get_waypoints_mask()
+
     def get_all_agents_absolute(self):
         return self.inner_simulator.get_all_agents_absolute()
 
@@ -1036,8 +1090,10 @@ class SimulatorWrapper(SimulatorInterface):
     def compute_wrong_way(self):
         return self.inner_simulator.compute_wrong_way()
 
-    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None):
-        return self.inner_simulator.render(camera_xy, camera_psi, res=res, rendering_mask=rendering_mask, fov=fov)
+    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None, waypoints=None,
+               waypoints_rendering_mask=None):
+        return self.inner_simulator.render(camera_xy, camera_psi, res=res, rendering_mask=rendering_mask, fov=fov,
+                                           waypoints=waypoints, waypoints_rendering_mask=waypoints_rendering_mask)
 
 
 class NPCWrapper(SimulatorWrapper):
@@ -1108,6 +1164,22 @@ class NPCWrapper(SimulatorWrapper):
             lambda x, k: x[..., k.logical_not(), :], self.inner_simulator.get_state(), self.npc_mask
         )
         return states
+
+    def get_waypoints(self):
+        waypoints = self.inner_simulator.get_waypoints()
+        if waypoints is not None:
+            waypoints = self.across_agent_types(
+                lambda x, k: x[..., k.logical_not(), :, :], waypoints, self.npc_mask
+            )
+        return waypoints
+
+    def get_waypoints_mask(self):
+        masks = self.inner_simulator.get_waypoints_mask()
+        if masks is not None:
+            masks = self.across_agent_types(
+                lambda x, k: x[..., k.logical_not(), :], masks, self.npc_mask
+            )
+        return masks
 
     def get_agent_size(self):
         sizes = self.across_agent_types(
@@ -1227,7 +1299,8 @@ class NPCWrapper(SimulatorWrapper):
         )
         self.inner_simulator.update_present_mask(new_present_mask)
 
-    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None):
+    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None, waypoints=None,
+               waypoints_rendering_mask=None):
         if rendering_mask is not None:
             def pad_rendering_mask(rd_mask, rpl_mask):
                 new_mask = torch.zeros(rd_mask.shape[0], rd_mask.shape[1], rpl_mask.shape[0], device=rd_mask.device)
@@ -1236,7 +1309,8 @@ class NPCWrapper(SimulatorWrapper):
             rendering_mask = self.across_agent_types(
                 pad_rendering_mask, rendering_mask, self.npc_mask
             )
-        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov)
+        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov, waypoints=waypoints,
+                                           waypoints_rendering_mask=waypoints_rendering_mask)
 
     def fit_action(self, future_state, current_state=None):
         full_state = self.inner_simulator.get_state()
@@ -1377,6 +1451,18 @@ class HomogeneousWrapper(SimulatorWrapper):
     def get_present_mask(self):
         return self.agent_concat(self.inner_simulator.get_present_mask(), agent_dim=-1)
 
+    def get_waypoints(self):
+        waypoints = self.inner_simulator.get_waypoints()
+        if waypoints is not None:
+            waypoints = self.agent_concat(waypoints, agent_dim=-3)
+        return waypoints
+
+    def get_waypoints_mask(self):
+        masks = self.inner_simulator.get_waypoints_mask()
+        if masks is not None:
+            masks = self.agent_concat(masks, agent_dim=-2)
+        return masks
+
     def get_all_agents_absolute(self):
         agent_info = self.inner_simulator.get_all_agents_absolute()
         return self.agent_concat(agent_info, agent_dim=-2, check_agent_count=False)
@@ -1422,9 +1508,11 @@ class HomogeneousWrapper(SimulatorWrapper):
             mask = self.agent_split(mask, agent_dim=-1)
         return self.agent_concat(self.inner_simulator._compute_collision_of_multi_agents(mask), agent_dim=-1)
 
-    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None):
+    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None, waypoints=None,
+               waypoints_rendering_mask=None):
         rendering_mask = self.agent_split(rendering_mask, -1) if rendering_mask is not None else None
-        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov)
+        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov, waypoints=waypoints,
+                                           waypoints_rendering_mask=waypoints_rendering_mask)
 
 
 class RecordingWrapper(SimulatorWrapper):
@@ -1758,6 +1846,18 @@ class SelectiveWrapper(SimulatorWrapper):
     def get_agent_type(self):
         return self._restrict_tensor(self.inner_simulator.get_agent_type(), agent_dim=-1)
 
+    def get_waypoints(self):
+        waypoints = self.inner_simulator.get_waypoints()
+        if waypoints is not None:
+            waypoints = self._restrict_tensor(waypoints, agent_dim=-3)
+        return waypoints
+
+    def get_waypoints_mask(self):
+        masks = self.inner_simulator.get_waypoints_mask()
+        if masks is not None:
+            masks = self._restrict_tensor(masks, agent_dim=-2)
+        return masks
+
     def get_all_agents_absolute(self):
         return self._restrict_tensor(self.inner_simulator.get_all_agents_absolute(), agent_dim=-2)
 
@@ -1783,14 +1883,16 @@ class SelectiveWrapper(SimulatorWrapper):
         action = self._restrict_tensor(extended_action, agent_dim=-2)
         return action
 
-    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None):
+    def render(self, camera_xy, camera_psi, res=None, rendering_mask=None, fov=None, waypoints=None,
+               waypoints_rendering_mask=None):
         if rendering_mask is not None:
             def padding_rendering_mask(rd_mask, expose_mask):
                 rd_mask = rd_mask.permute(0, 2, 1)
                 pad_tensor = torch.zeros(rd_mask.shape[0], expose_mask.shape[1], rd_mask.shape[1], device=rd_mask.device)
                 return self._extend_tensor(rd_mask, pad_tensor).permute(0, 2, 1)
             rendering_mask = self.across_agent_types(padding_rendering_mask, rendering_mask, self.is_exposed())
-        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov)
+        return self.inner_simulator.render(camera_xy, camera_psi, res, rendering_mask, fov=fov, waypoints=waypoints,
+                                           waypoints_rendering_mask=waypoints_rendering_mask)
 
     def step(self, action):
         extended_action = self._extend_tensor(action, padding=self.default_action)


### PR DESCRIPTION
Since waypoints can be different between agents, the given waypoint positions should be given per camera. This PR does not address on how the simulator should handle waypoint goal points (not sure if this should actually be implemented in the simulator in the first place).