### PR TITLE
OpenCV renderer replacing PyTorch3D as the default

### DIFF
--- a/.github/workflows/CI_cpu.yml
+++ b/.github/workflows/CI_cpu.yml
@@ -1,0 +1,38 @@
+name: CI_cpu
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install lanelet2 pytest && pip install .
+
+    - name: Run tests
+      run: |
+        pytest -s -m "not depends_on_cuda and not depends_on_pytorch3d and not depends_on_nvdiffrast" tests

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI_gpu
 
 # Controls when the workflow will run
 on:
@@ -19,6 +19,8 @@ jobs:
    steps:
      - uses: actions/checkout@v2
      - uses: docker/setup-buildx-action@v2
+     - name: Delete huge unnecessary tools folder
+       run: rm -rf /opt/hostedtoolcache
      - uses: docker/build-push-action@v4
        with:
            context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,34 @@
-FROM nvidia/cudagl:11.2.2-devel-ubuntu20.04 as torchdrivesim-base
+FROM nvidia/cudagl:11.4.2-devel-ubuntu20.04 as torchdrivesim-base
 # This file is for building the production api server only.
 
-# Install general utilities
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata software-properties-common && add-apt-repository universe && apt update && apt install -y locales-all  git curl sed nano
+# Install general utilities, Python, related tooling, C compilers, build systems, and Lanelet2 dependencies in one go
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    tzdata software-properties-common locales-all git curl sed nano \
+    libffi-dev  \
+    build-essential llvm libxml2-dev cmake autoconf ninja-build \
+    clang-8 lld-8 g++-7 libpng-dev libtiff5-dev libjpeg-dev \
+    libtool libxml2-dev libxerces-c-dev libboost-all-dev libeigen3-dev \
+    libgeographic-dev libpugixml-dev libboost-python-dev --no-install-recommends \
+ && add-apt-repository ppa:deadsnakes/ppa \
+ && apt-get update && apt-get install -y python3.10 python3.10-venv python3.10-dev wget\
+ && wget https://bootstrap.pypa.io/get-pip.py && python3.10 get-pip.py \
+ && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
+ && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
+ && pip install --no-cache-dir setuptools distro wheel \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-# Install Python and related tooling
-RUN apt install -y libffi-dev python python-dev python3-dev python3-pip python3-venv \
-  && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
-  && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 \
-  && pip install setuptools distro wheel \
-  && apt install -y build-essential llvm libxml2-dev
+ENV DEBIAN_FRONTEND=
 
-# Install pytorch and pytorch3d
-RUN pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 -f https://download.pytorch.org/whl/torch_stable.html
-RUN pip install pytorch3d==0.7.2 -f https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py38_cu113_pyt1110/download.html
+# Install pytorch, pytorch3d and lanelet2
+RUN pip install --no-cache-dir \
+    torch==2.1.2+cu118 torchvision==0.16.2+cu118 -f https://download.pytorch.org/whl/torch_stable.html \
+    pytorch3d==0.7.5 -f https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py310_cu118_pyt210/download.html \
+    lanelet2
 
-# Set up C compilers and build systems
-RUN apt update && apt install -y build-essential cmake autoconf ninja-build \
-  clang-8 lld-8 g++-7 \
-  libpng-dev libtiff5-dev libjpeg-dev libtool libxml2-dev libxerces-c-dev
-
-# Install Lanelet2
+# Install Lanelet2 dependencies
 RUN apt update \
   && apt install -y libboost-all-dev libeigen3-dev libgeographic-dev libpugixml-dev libboost-python-dev
-COPY resources/dependencies/lanelet2/lanelet2-0.1.0-cp38-cp38-linux_x86_64.whl /opt/lanelet2-0.1.0-cp38-cp38-linux_x86_64.whl
-RUN pip install /opt/lanelet2-0.1.0-cp38-cp38-linux_x86_64.whl
 
 
 WORKDIR /opt
@@ -34,9 +38,11 @@ FROM torchdrivesim-base as torchdrivesim-tests
 
 COPY tests /opt/tests
 COPY requirements/dev.txt /opt/requirements.txt
-RUN pip install -r /opt/requirements.txt
+RUN pip install --no-cache-dir -r /opt/requirements.txt
+COPY . /opt/torchdrivesim
+RUN cd torchdrivesim && pip install .
 COPY pytest.ini /opt/pytest.ini
-CMD ["pytest", "-s", "-m", "not depends_on_cuda", "tests"]
+CMD ["pytest", "-s", "-m", "not depends_on_nvdiffrast", "tests"]
 
 FROM torchdrivesim-base as torchdrivesim
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ environment for developing autonomous driving algorithms. Its main features are:
 8. Ability to ingest any map in [Lanelet2](https://github.com/fzi-forschungszentrum-informatik/Lanelet2) format out of the box.
 9. Integration with [IAI API](https://docs.inverted.ai/en/latest/) for initializing agent states and providing realistic behaviors.
 <!-- end Features-->
+### ** Warning **
+The PyPI version of torchdrivesim (which is what you get when you run `pip install torchdrivesim`) comes equipped
+only with the slower OpenCV renderer. Faster renderers are available, but require either 
+[`pytorch3d`](https://github.com/facebookresearch/pytorch3d/) or 
+[`nvdiffrast`](https://nvlabs.github.io/nvdiffrast/)
+to be installed. Their CUDA dependencies can be tricky to satisfy, so we provide a suitable Dockerfile.
 
 <!-- start readme-->
 ## Simulator Architecture
@@ -86,17 +92,20 @@ straightforward to implement a custom one.
 
 ## Differentiable rendering
 
-TorchDriveSim supports two rendering backends, namely pytorch3d and nvdiffrast, both producing results that look the
-same to the human eye. Pytorch3d is the default one and a required dependency, since it's easier to install. Nvdiffrast
-is supported and can sometimes be substantially faster, but it needs to be installed separately, and it's subject
-to more restrictive license conditions. We also provide a dummy rendering backend that returns an empty image,
-mostly for debugging and benchmarking purposes.
+TorchDriveSim supports three rendering backends, using cv2, pytorch3d, and nvdiffrast, respectively. The images produced
+by all three look very similar and differ only in the details of how different triangles are pixelated.
+The cv2 backend is the easiest to install and it is included as a required dependency. Pytorch3d and nvdiffrast
+need to be installed separately, as per the instructions below. We also provide a dummy rendering backend that
+returns an empty image, mostly for debugging and benchmarking purposes.
 
 ## Installation
 
-Before running the usual `pip install torchdrivesim` command, correct `torch` and `pytorch3d` versions need to be 
-installed by the user. `torchdrivesim` will assume the user have installed
-the correct version already as `Pytorch` related packages are marked as optional.
+Running `pip install torchdrivesim` only provides access to the basic OpenCV renderer. To be able to use the faster
+pytorch3d renderer, make sure to first install the correct versions of `torch` and `pytorch3d` using the instructions
+below. You can also install [`nvdiffrast`](https://nvlabs.github.io/nvdiffrast/#installation), which can be even faster,
+but it is also subject to more restrictive license conditions.
+Generally, the more images you render in parallel (either by having more ego agents or larger batches), the more
+of a gain you will get from the faster renderers.
 
 To install the correct `torch` using `pip`, go visit the
 [prebuilt whls page](https://download.pytorch.org/whl/torch_stable.html) to select the right `.whl` file based on the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [pypi-badge]: https://badge.fury.io/py/torchdrivesim.svg
 [pypi-link]: https://pypi.org/project/torchdrivesim/  
+[python-badge]: https://img.shields.io/pypi/pyversions/torchdrivesim.svg?color=%2334D058
 [![CI](https://github.com/inverted-ai/torchdrivesim/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/inverted-ai/torchdrivesim/actions/workflows/CI.yml)
 [![PyPI][pypi-badge]][pypi-link]
+[![python-badge]][pypi-link]
 [![Documentation Status](https://readthedocs.org/projects/torchdrivesim/badge/?version=latest)](https://readthedocs.org/projects/torchdrivesim/badge/?version=latest)
 
 # TorchDriveSim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "torch>=1.10.1",
     "invertedai",
     "omegaconf",
-    "cv2",
+    "opencv-python",
 ]
 dynamic = ["version",]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "scipy",
     "imageio",
     "torch>=1.10.1",
-    "pytorch3d",
     "invertedai",
     "omegaconf",
     "cv2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "torch>=1.10.1",
     "pytorch3d",
     "invertedai",
-    "omegaconf"
+    "omegaconf",
+    "cv2",
 ]
 dynamic = ["version",]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ markers =
     integration: mark the test as an integration test.
     depends_on_lanelet2: mark the test as dependent on lanelet2.
     depends_on_cuda: mark the test as dependent on cuda.
+    depends_on_pytorch3d: mark the test as dependent on pytorch3d.
+    depends_on_nvdiffrast: mark the test as dependent on nvdiffrast.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,9 @@ shapely
 scipy
 imageio
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.11.0+cu113
---find-links https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py38_cu113_pyt1110/download.html
-pytorch3d==0.7.2
+torch==2.1.2+cu118
+--find-links  https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py310_cu118_pyt210/download.html
+pytorch3d==0.7.5
 omegaconf
 invertedai
-pytest==5.4.3
+pytest>=5.4.3

--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -157,7 +157,6 @@ class TestBaseSimulator:
         collision_metrics = self.get_tensor(self.simulator.compute_collision())
         assert len(collision_metrics.shape) == 2 and torch.all(collision_metrics)
 
-    @pytest.mark.depends_on_pytorch3d
     def test_compute_offroad(self):
         assert self.get_tensor(self.simulator.compute_offroad()).shape == self.offroad_shape
 

--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -1,5 +1,4 @@
 import os
-import lanelet2
 import pytest
 import torch
 from torchdrivesim.simulator import TorchDriveConfig, Simulator
@@ -62,6 +61,7 @@ class TestBaseSimulator:
 
     @classmethod
     def get_simulator(cls):
+        import lanelet2
         road_mesh = BirdviewMesh.empty(batch_size=cls.data_batch_size)
         kinematic_model = KinematicBicycle()
         kinematic_model.set_params(lr=cls.mock_agent_attributes[..., 2])
@@ -157,6 +157,7 @@ class TestBaseSimulator:
         collision_metrics = self.get_tensor(self.simulator.compute_collision())
         assert len(collision_metrics.shape) == 2 and torch.all(collision_metrics)
 
+    @pytest.mark.depends_on_pytorch3d
     def test_compute_offroad(self):
         assert self.get_tensor(self.simulator.compute_offroad()).shape == self.offroad_shape
 

--- a/tests/simulator/test_wrapped_simulators.py
+++ b/tests/simulator/test_wrapped_simulators.py
@@ -49,11 +49,16 @@ class TestHomogenousSimulator(TestBaseWrappedSimulator):
         return HomogeneousWrapper(super().get_simulator())
 
     @pytest.mark.parametrize('collision_metric_type', [cm for cm in (CollisionMetric.nograd,
-                                                                     # CollisionMetric.nograd_pytorch3d,
                                                                      CollisionMetric.iou, CollisionMetric.discs)])
     def test_compute_collision(self, collision_metric_type):
 
         self.simulator.cfg.collision_metric = collision_metric_type
+        collision_metrics = self.simulator.compute_collision()
+        assert len(collision_metrics.shape) == 2 and not torch.all(collision_metrics)
+
+    @pytest.mark.depends_on_pytorch3d
+    def test_compute_collision_pytorch3d(self):
+        self.simulator.cfg.collision_metric = CollisionMetric.nograd_pytorch3d
         collision_metrics = self.simulator.compute_collision()
         assert len(collision_metrics.shape) == 2 and not torch.all(collision_metrics)
 

--- a/tests/simulator/test_wrapped_simulators.py
+++ b/tests/simulator/test_wrapped_simulators.py
@@ -49,7 +49,7 @@ class TestHomogenousSimulator(TestBaseWrappedSimulator):
         return HomogeneousWrapper(super().get_simulator())
 
     @pytest.mark.parametrize('collision_metric_type', [cm for cm in (CollisionMetric.nograd,
-                                                                     CollisionMetric.nograd_pytorch3d,
+                                                                     # CollisionMetric.nograd_pytorch3d,
                                                                      CollisionMetric.iou, CollisionMetric.discs)])
     def test_compute_collision(self, collision_metric_type):
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2,6 +2,7 @@ import dataclasses
 import os
 import shutil
 
+import pytest
 import torch
 
 from torchdrivesim.mesh import BaseMesh, AttributeMesh, BirdviewMesh
@@ -55,6 +56,7 @@ class TestBaseMesh:
         _ = self.mesh.pickle(save_path)
         _ = self.mesh.unpickle(save_path)
 
+    @pytest.mark.depends_on_pytorch3d
     def test_pytorch3d(self):
         self.mesh.pytorch3d()
 
@@ -67,6 +69,7 @@ class TestBaseMesh:
         saved_mesh = self.mesh.load(os.path.join(self.save_dir, 'test_mesh.json'))
         assert torch.equal(self.mesh.verts, saved_mesh.verts)
         assert torch.equal(self.mesh.faces, saved_mesh.faces)
+
 
 class TestAttributeMesh(TestBaseMesh):
     mesh = None
@@ -105,6 +108,7 @@ class TestAttributeMesh(TestBaseMesh):
         assert torch.equal(self.mesh.verts, saved_mesh.verts)
         assert torch.equal(self.mesh.faces, saved_mesh.faces)
         assert torch.equal(self.mesh.attrs, saved_mesh.attrs)
+
 
 class TestBirdviewMesh(TestBaseMesh):
     mesh = None

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,5 +1,5 @@
 from torchdrivesim.rendering import Pytorch3DRendererConfig, RendererConfig, CV2RendererConfig, \
-    renderer_from_config
+    renderer_from_config, DummyRendererConfig
 import torch
 import pytest
 
@@ -11,6 +11,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
     Pytorch3DRendererConfig(highlight_ego_vehicle=True),
     Pytorch3DRendererConfig(),
     CV2RendererConfig(),
+    DummyRendererConfig(),
 ])
 def test_render_agents(cfg: RendererConfig):
     batch_size = 2

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,15 +1,23 @@
-from torchdrivesim.rendering import NvdiffrastRendererConfig, Pytorch3DRendererConfig, RendererConfig, renderer_from_config
+from torchdrivesim.rendering import Pytorch3DRendererConfig, RendererConfig, renderer_from_config
 import torch
 import pytest
 
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
-@pytest.mark.parametrize("cfg", [Pytorch3DRendererConfig(highlight_ego_vehicle=True),Pytorch3DRendererConfig()])
+
+
+@pytest.mark.parametrize("cfg", [
+    Pytorch3DRendererConfig(highlight_ego_vehicle=True),
+    Pytorch3DRendererConfig()
+])
 def test_render_agents(cfg: RendererConfig):
     batch_size = 2
     renderer = renderer_from_config(cfg, batch_size=batch_size).to(device)
     agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
     agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
-    waypoints = torch.zeros(batch_size, 3, 2, 3).to(device)
+    waypoints = torch.zeros(batch_size, 3, 2, 2).to(device)
     waypoints_mask = torch.ones(waypoints.shape[:-1], device=waypoints.device, dtype=torch.bool)
-    renderer.render_frame(agents_states, agents_attributes, waypoints=waypoints, waypoints_rendering_mask=waypoints_mask)
+    renderer.render_frame(
+        agents_states, agents_attributes,
+        waypoints=waypoints, waypoints_rendering_mask=waypoints_mask
+    )

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,4 +1,5 @@
-from torchdrivesim.rendering import Pytorch3DRendererConfig, RendererConfig, renderer_from_config
+from torchdrivesim.rendering import Pytorch3DRendererConfig, RendererConfig, CV2RendererConfig, \
+    renderer_from_config
 import torch
 import pytest
 
@@ -8,7 +9,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 
 @pytest.mark.parametrize("cfg", [
     Pytorch3DRendererConfig(highlight_ego_vehicle=True),
-    Pytorch3DRendererConfig()
+    Pytorch3DRendererConfig(),
+    CV2RendererConfig(),
 ])
 def test_render_agents(cfg: RendererConfig):
     batch_size = 2

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -7,21 +7,52 @@ import pytest
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
 
-@pytest.mark.parametrize("cfg", [
-    RendererConfig(highlight_ego_vehicle=True),
-    Pytorch3DRendererConfig(),
-    CV2RendererConfig(),
-    DummyRendererConfig(),
-    NvdiffrastRendererConfig(opengl=False),
-])
-def test_render_agents(cfg: RendererConfig):
-    batch_size = 2
-    renderer = renderer_from_config(cfg, batch_size=batch_size).to(device)
-    agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
-    agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
-    waypoints = torch.zeros(batch_size, 3, 2, 2).to(device)
-    waypoints_mask = torch.ones(waypoints.shape[:-1], device=waypoints.device, dtype=torch.bool)
-    renderer.render_frame(
-        agents_states, agents_attributes,
-        waypoints=waypoints, waypoints_rendering_mask=waypoints_mask
-    )
+class TestRenderer:
+    cfg: RendererConfig = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = RendererConfig(highlight_ego_vehicle=True)
+
+    @classmethod
+    def test_render_agents(cls):
+        batch_size = 2
+        renderer = renderer_from_config(cls.cfg, batch_size=batch_size).to(device)
+        agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
+        agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
+        waypoints = torch.zeros(batch_size, 3, 2, 2).to(device)
+        waypoints_mask = torch.ones(waypoints.shape[:-1], device=waypoints.device, dtype=torch.bool)
+        renderer.render_frame(
+            agents_states, agents_attributes,
+            waypoints=waypoints, waypoints_rendering_mask=waypoints_mask
+        )
+
+
+class TestDummyRenderer(TestRenderer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = DummyRendererConfig()
+
+
+class TestCV2Renderer(TestRenderer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = CV2RendererConfig()
+
+
+@pytest.mark.depends_on_pytorch3d
+class TestPytorch3DRenderer(TestRenderer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = Pytorch3DRendererConfig()
+
+
+@pytest.mark.depends_on_nvdiffrast
+class TestNvdiffrastRenderer(TestRenderer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = NvdiffrastRendererConfig()

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -14,10 +14,9 @@ class TestRenderer:
     def setup_class(cls):
         cls.cfg = RendererConfig(highlight_ego_vehicle=True)
 
-    @classmethod
-    def test_render_agents(cls):
+    def test_render_agents(self):
         batch_size = 2
-        renderer = renderer_from_config(cls.cfg, batch_size=batch_size).to(device)
+        renderer = renderer_from_config(self.cfg, batch_size=batch_size).to(device)
         agents_states = {"vehicle": torch.zeros(batch_size, 3, 4).to(device)}
         agents_attributes = {"vehicle": torch.ones(batch_size, 3, 3).to(device)}
         waypoints = torch.zeros(batch_size, 3, 2, 2).to(device)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -8,7 +8,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 
 
 @pytest.mark.parametrize("cfg", [
-    Pytorch3DRendererConfig(highlight_ego_vehicle=True),
+    RendererConfig(highlight_ego_vehicle=True),
     Pytorch3DRendererConfig(),
     CV2RendererConfig(),
     DummyRendererConfig(),

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,5 +1,5 @@
 from torchdrivesim.rendering import Pytorch3DRendererConfig, RendererConfig, CV2RendererConfig, \
-    renderer_from_config, DummyRendererConfig
+    renderer_from_config, DummyRendererConfig, NvdiffrastRendererConfig
 import torch
 import pytest
 
@@ -12,6 +12,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
     Pytorch3DRendererConfig(),
     CV2RendererConfig(),
     DummyRendererConfig(),
+    NvdiffrastRendererConfig(opengl=False),
 ])
 def test_render_agents(cfg: RendererConfig):
     batch_size = 2

--- a/torchdrivesim/__init__.py
+++ b/torchdrivesim/__init__.py
@@ -1,1 +1,8 @@
 __version__ = "0.1.0"
+
+
+def assert_pytorch3d_available():
+    from torchdrivesim.rendering.pytorch3d import is_available as pytorch3d_available
+    if not pytorch3d_available:
+        from torchdrivesim.rendering.pytorch3d import Pytorch3DNotFound
+        raise Pytorch3DNotFound()

--- a/torchdrivesim/infractions.py
+++ b/torchdrivesim/infractions.py
@@ -11,7 +11,8 @@ from torch.nn import functional as F
 import torchdrivesim
 from torchdrivesim._iou_utils import box2corners_th, iou_differentiable_fast, iou_non_differentiable
 from torchdrivesim.lanelet2 import LaneletMap, find_lanelet_directions, LaneletError
-from torchdrivesim.mesh import BaseMesh, check_pytorch3d_available
+from torchdrivesim.mesh import BaseMesh
+from torchdrivesim import assert_pytorch3d_available
 from torchdrivesim.rendering.pytorch3d import Pytorch3DNotFound
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ def point_mesh_face_distance(meshes: "pytorch3d.structures.Meshes", pcls: "pytor
         BxP tensor if reduction is 'none', else Bx1 tensor
     """
 
-    check_pytorch3d_available()
+    assert_pytorch3d_available()
     from pytorch3d.loss.point_mesh_distance import point_face_distance
 
     if len(meshes) != len(pcls):
@@ -204,7 +205,7 @@ def offroad_infraction_loss(agent_states: Tensor, lenwid: Tensor,
     ego_verts = box2corners_th(predicted_rectangles)
     ego_verts = F.pad(ego_verts, (0,1))
     if use_pytorch3d:
-        check_pytorch3d_available()
+        assert_pytorch3d_available()
         import pytorch3d
         ego_verts = ego_verts.view(-1, *ego_verts.shape[2:])  # B*A x 4 x 3
         ego_pointclouds = pytorch3d.structures.Pointclouds(ego_verts)

--- a/torchdrivesim/infractions.py
+++ b/torchdrivesim/infractions.py
@@ -93,7 +93,7 @@ def point_to_mesh_distance_pt(points: torch.Tensor, tris: torch.Tensor, threshol
     Returns:
         Bx1 tensor
     """
-    
+
     p = points.unsqueeze(1)
     v0, v1, v2 = tris.unbind(dim=-2)
     cross = torch.cross(v2 - v0, v1 - v0, dim=-1)
@@ -187,7 +187,7 @@ def offroad_infraction_loss(agent_states: Tensor, lenwid: Tensor,
     """
 
     batch_size, num_agents = agent_states.shape[:2]
-    if num_agents == 0:
+    if num_agents == 0 or driving_surface_mesh.faces_count == 0:
         return torch.zeros_like(agent_states[..., 0])
     if len(lenwid.shape) == 2:
         lenwid = lenwid.unsqueeze(-2).expand((lenwid.shape[0], num_agents, lenwid.shape[1]))

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -18,6 +18,7 @@ import torch
 from torch import Tensor
 from torch.nn.utils.rnn import pad_sequence
 
+from torchdrivesim import assert_pytorch3d_available
 from torchdrivesim.utils import is_inside_polygon, merge_dicts, rotate
 
 logger = logging.getLogger(__name__)
@@ -202,7 +203,7 @@ class BaseMesh:
         Empty meshes are augmented with a single degenerate face on conversion,
         since PyTorch3D does not handle empty meshes correctly.
         """
-        check_pytorch3d_available()
+        assert_pytorch3d_available()
         import pytorch3d
         assert self.dim in [2, 3]
         if self.faces_count == 0:
@@ -420,7 +421,7 @@ class AttributeMesh(BaseMesh):
         PyTorch3D uses per-face textures, which are obtained by averaging attributes of the face.
         The resulting texture for each face is constant.
         """
-        check_pytorch3d_available()
+        assert_pytorch3d_available()
         import pytorch3d
         assert self.dim in [2, 3]
         if not include_textures:
@@ -832,10 +833,3 @@ def generate_disc_mesh(radius: float = 2, num_triangles: int = 10, device: str =
     vertices = torch.cat(vertices, dim=0)
     faces = torch.cat(faces, dim=0)
     return vertices, faces
-
-
-def check_pytorch3d_available():
-    from torchdrivesim.rendering.pytorch3d import is_available as pytorch3d_available
-    if not pytorch3d_available:
-        from torchdrivesim.rendering.pytorch3d import Pytorch3DNotFound
-        raise Pytorch3DNotFound()

--- a/torchdrivesim/rendering/__init__.py
+++ b/torchdrivesim/rendering/__init__.py
@@ -8,6 +8,7 @@ from omegaconf import DictConfig, OmegaConf, SCMode
 
 
 from torchdrivesim.rendering.base import RendererConfig, DummyRendererConfig, BirdviewRenderer, DummyRenderer
+from torchdrivesim.rendering.cv2 import CV2RendererConfig, CV2Renderer
 from torchdrivesim.rendering.pytorch3d import Pytorch3DRendererConfig, Pytorch3DRenderer
 from torchdrivesim.rendering.nvdiffrast import NvdiffrastRendererConfig, NvdiffrastRenderer
 
@@ -32,6 +33,8 @@ def renderer_from_config(cfg: RendererConfig, *args, **kwargs) -> BirdviewRender
 
     if isinstance(cfg, DummyRendererConfig):
         return DummyRenderer(cfg, *args, **kwargs)
+    elif isinstance(cfg, CV2RendererConfig):
+        return CV2Renderer(cfg, *args, **kwargs)
     elif isinstance(cfg, Pytorch3DRendererConfig):
         return Pytorch3DRenderer(cfg, *args, **kwargs)
     elif isinstance(cfg, NvdiffrastRendererConfig):

--- a/torchdrivesim/rendering/__init__.py
+++ b/torchdrivesim/rendering/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 from omegaconf import DictConfig, OmegaConf, SCMode
 
-
+import torchdrivesim.rendering.pytorch3d
 from torchdrivesim.rendering.base import RendererConfig, DummyRendererConfig, BirdviewRenderer, DummyRenderer
 from torchdrivesim.rendering.cv2 import CV2RendererConfig, CV2Renderer
 from torchdrivesim.rendering.pytorch3d import Pytorch3DRendererConfig, Pytorch3DRenderer
@@ -25,11 +25,18 @@ def renderer_from_config(cfg: RendererConfig, *args, **kwargs) -> BirdviewRender
     assert isinstance(cfg, RendererConfig)
 
     if cfg.backend == 'default':
-        cfg = Pytorch3DRendererConfig(
-            left_handed_coordinates=cfg.left_handed_coordinates,
-            render_agent_direction=cfg.render_agent_direction,
-            highlight_ego_vehicle=cfg.highlight_ego_vehicle
-        )
+        if torchdrivesim.rendering.pytorch3d.is_available:
+            cfg = Pytorch3DRendererConfig(
+                left_handed_coordinates=cfg.left_handed_coordinates,
+                render_agent_direction=cfg.render_agent_direction,
+                highlight_ego_vehicle=cfg.highlight_ego_vehicle
+            )
+        else:
+            cfg = CV2RendererConfig(
+                left_handed_coordinates=cfg.left_handed_coordinates,
+                render_agent_direction=cfg.render_agent_direction,
+                highlight_ego_vehicle=cfg.highlight_ego_vehicle
+            )
 
     if isinstance(cfg, DummyRendererConfig):
         return DummyRenderer(cfg, *args, **kwargs)

--- a/torchdrivesim/rendering/__init__.py
+++ b/torchdrivesim/rendering/__init__.py
@@ -1,6 +1,6 @@
 """
 Renderers used to visualize the state of the environments.
-Currently two backends are supported (pytorch3d and nvdiffrast), along with a dummy renderer generating black images.
+Currently three backends are supported (opencv, pytorch3d and nvdiffrast), along with a dummy renderer generating black images.
 """
 import logging
 

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 
 import cv2
 import numpy as np
-import pytorch3d
 import torch
 
 from torchdrivesim.mesh import BirdviewMesh, tensor_color
 from torchdrivesim.rendering import BirdviewRenderer, RendererConfig
+from torchdrivesim.rendering.base import Cameras
 from torchdrivesim.utils import Resolution
 
 
@@ -23,9 +23,9 @@ class CV2Renderer(BirdviewRenderer):
         super().__init__(cfg, *args, **kwargs)
         self.cfg: CV2RendererConfig = cfg
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: pytorch3d.renderer.FoVOrthographicCameras)\
-            -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
 
+        cameras = cameras.pytorch3d()
         image_batch = []
         padded_verts = torch.cat([mesh.verts, torch.zeros_like(mesh.verts[..., :1])], dim=-1)
         pixel_verts = cameras.transform_points_screen(

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -25,12 +25,8 @@ class CV2Renderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
 
-        cameras = cameras.pytorch3d()
         image_batch = []
-        padded_verts = torch.cat([mesh.verts, torch.zeros_like(mesh.verts[..., :1])], dim=-1)
-        pixel_verts = cameras.transform_points_screen(
-            padded_verts, image_size=(res.height, res.width)
-        )[..., :2].cpu().to(torch.int32)
+        pixel_verts = cameras.transform_points_screen(mesh.verts, res=res).cpu().to(torch.int32)
 
         for k in mesh.categories:
             if k not in mesh.colors:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -61,7 +61,7 @@ class NvdiffrastRendererConfig(RendererConfig):
     """
     backend: str = 'nvdiffrast'
     antialias: bool = False
-    opengl: bool = True  #: if False, use CUDA for rendering
+    opengl: bool = False  #: if False, use CUDA for rendering
     max_minibatch_size: Optional[int] = None  #: used to pre-allocate memory, which may speed up rendering
 
 

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -9,6 +9,8 @@ import logging
 import torch
 from torch.nn import functional as F
 
+from torchdrivesim.rendering.pytorch3d import construct_pytorch3d_cameras
+
 try:
     import nvdiffrast.torch as dr
     is_available = True
@@ -80,7 +82,7 @@ class NvdiffrastRenderer(BirdviewRenderer):
             raise RuntimeError('Failed to obtain glctx session for nvdiffrast')
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
-        cameras = cameras.pytorch3d()
+        cameras = construct_pytorch3d_cameras(cameras)
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -9,6 +9,7 @@ import logging
 import torch
 from torch.nn import functional as F
 
+import torchdrivesim.rendering.pytorch3d
 from torchdrivesim.rendering.pytorch3d import construct_pytorch3d_cameras
 
 try:
@@ -82,6 +83,10 @@ class NvdiffrastRenderer(BirdviewRenderer):
             raise RuntimeError('Failed to obtain glctx session for nvdiffrast')
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+        if not torchdrivesim.rendering.pytorch3d.is_available:
+            raise torchdrivesim.rendering.pytorch3d.Pytorch3DNotFound(
+                'Rendering with nvdiffrast currently requires pytorch3d'
+            )
         cameras = construct_pytorch3d_cameras(cameras)
         for k in mesh.categories:
             if k not in mesh.colors:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -107,7 +107,6 @@ class NvdiffrastRenderer(BirdviewRenderer):
         vertices_attributes = mesh.attrs.reshape(-1, 3)
         rast, _ = dr.rasterize(self.glctx, verts_clip, faces, resolution=[res.height, res.width],
                                ranges=ranges)
-        vertices_attributes = mesh.attrs.reshape(-1, 3)
         image, _ = dr.interpolate(vertices_attributes, rast, faces)
         # Change background color in case it's not black
         if sum(self.get_color('background')) != 0:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -4,13 +4,10 @@ This module imports correctly if nvdiffrast is missing, but the renderer will ra
 """
 from dataclasses import dataclass
 from typing import Optional
-
-import torch
-
 import logging
 
+import torch
 from torch.nn import functional as F
-import pytorch3d
 
 try:
     import nvdiffrast.torch as dr
@@ -20,7 +17,7 @@ except ImportError:
     is_available = False
 
 from torchdrivesim.mesh import BirdviewMesh, tensor_color
-from torchdrivesim.rendering.base import RendererConfig, BirdviewRenderer
+from torchdrivesim.rendering.base import RendererConfig, BirdviewRenderer, Cameras
 from torchdrivesim.utils import Resolution
 
 logger = logging.getLogger(__name__)
@@ -82,8 +79,8 @@ class NvdiffrastRenderer(BirdviewRenderer):
         if self.glctx is None:
             raise RuntimeError('Failed to obtain glctx session for nvdiffrast')
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: pytorch3d.renderer.FoVOrthographicCameras)\
-            -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+        cameras = cameras.pytorch3d()
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -10,7 +10,7 @@ import torch
 from pytorch3d.renderer import BlendParams
 
 from torchdrivesim.mesh import BirdviewMesh, tensor_color
-from torchdrivesim.rendering.base import RendererConfig, BirdviewRenderer
+from torchdrivesim.rendering.base import RendererConfig, BirdviewRenderer, Cameras
 from torchdrivesim.utils import Resolution
 
 
@@ -73,8 +73,8 @@ class Pytorch3DRenderer(BirdviewRenderer):
             background_color=tuple([x / 255.0 for x in self.get_color('background')])
         )
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: pytorch3d.renderer.FoVOrthographicCameras)\
-            -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+        cameras = cameras.pytorch3d()
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -14,6 +14,7 @@ import torch
 from torch import Tensor
 from torch.nn.functional import pad
 
+import torchdrivesim.rendering.pytorch3d
 from torchdrivesim.goals import WaypointGoal
 from torchdrivesim.kinematic import KinematicModel
 from torchdrivesim.lanelet2 import LaneletMap
@@ -977,6 +978,10 @@ class Simulator(SimulatorInterface):
                 compute_agent_collisions_metric(all_presented_boxes, all_presented_collision_masks, present_mask),
                 device=device)
         elif self.cfg.collision_metric == CollisionMetric.nograd_pytorch3d:
+            if not torchdrivesim.rendering.pytorch3d.is_available:
+                raise torchdrivesim.rendering.pytorch3d.Pytorch3DNotFound(
+                    "You can use a different collision metric, e.g. CollisionMetric.nograd"
+                )
             all_boxes = torch.cat([states[..., :2], sizes, states[..., 2:3]], dim=-1)
             collision = compute_agent_collisions_metric_pytorch3d(all_boxes, collision_mask)
         else:

--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from itertools import accumulate
 from typing import Optional, Union, Dict, List, Iterable, Callable, Any
@@ -43,9 +43,9 @@ class TorchDriveConfig:
     """
     Top-level configuration for a TorchDriveSim simulator.
     """
-    renderer: RendererConfig = RendererConfig()  #: how to visualize the world, for the user and for the agents
+    renderer: RendererConfig = field(default_factory=lambda:RendererConfig())  #: how to visualize the world, for the user and for the agents
     single_agent_rendering: bool = False  #: if set, agents don't see each other
-    collision_metric: CollisionMetric = CollisionMetric.discs  #: method to use for computing collisions
+    collision_metric: CollisionMetric = field(default_factory=lambda:CollisionMetric.discs)  #: method to use for computing collisions
     offroad_threshold: float = 0.5  #: how much the agents can go off-road without counting that as infraction
     left_handed_coordinates: bool = False  #: whether the coordinate system is left-handed (z always points upwards)
 


### PR DESCRIPTION
This PR adds a cv2 renderer and makes pytorch3d an optional dependency. That means people will be able to pip-install a fully functional version of torchdrivesim without any extra hassle. The new renderer is CPU-only, and it seems to run fast enough to render the view of one agent in real time, but it is sequential, so it will be quite slow for multiple ego agents or batches.

I extended tests to cover all the different backends, and I confirmed that the package installs correctly with pip in a fresh environment, and that the tests pass as expected (skipping those that depend on either pytorch3d or nvdiffrast). Below I show some comparisons of an example frame with different renderers:

cv2
![cv2](https://github.com/inverted-ai/torchdrivesim/assets/3524715/498b5952-41ac-458a-8661-ad0d6733e25d)
![cv2_egocentric](https://github.com/inverted-ai/torchdrivesim/assets/3524715/462d6262-698c-4f4e-b758-7d7b86c1b473)

pytorch3d
![pytorch3d](https://github.com/inverted-ai/torchdrivesim/assets/3524715/e452d01c-5b86-4cb3-90fd-d93098a479b7)
![pytorch3d_egocentric](https://github.com/inverted-ai/torchdrivesim/assets/3524715/d716e5eb-5b76-4378-86f7-6eb7d28c28f8)

nvdiffrast
![nvdiffrast](https://github.com/inverted-ai/torchdrivesim/assets/3524715/47e264a8-db7d-4bb0-8e65-60ff267ac339)
![nvdiffrast_egocentric](https://github.com/inverted-ai/torchdrivesim/assets/3524715/5f58b606-49ba-4b70-ac0a-42415fc53b91)
