### PR TITLE
bug fix to light state machines

### DIFF
--- a/tests/test_traffic_light_state_machine.py
+++ b/tests/test_traffic_light_state_machine.py
@@ -68,6 +68,54 @@ def test_tick(traffic_light_state_machine: TrafficLightStateMachine):
         next_state=2)
 
 
+def test_tick_large_dt_middle_of_state(traffic_light_state_machine: TrafficLightStateMachine):
+    traffic_light_state_machine.set_to(0, 10)
+    traffic_light_state_machine.tick(23)
+    assert traffic_light_state_machine.current_state == TrafficLightGroupState(
+        actor_states={
+                "4411": TrafficLightState.green,
+                "3411": TrafficLightState.red,
+                "4399": TrafficLightState.yellow,
+                "3399": TrafficLightState.yellow
+            },
+        sequence_number=2,
+        duration=5,
+        next_state=3)
+    assert traffic_light_state_machine.time_remaining == 2
+
+
+def test_tick_large_dt_end_of_state(traffic_light_state_machine: TrafficLightStateMachine):
+    traffic_light_state_machine.set_to(0, 10)
+    traffic_light_state_machine.tick(25)
+    assert traffic_light_state_machine.current_state == TrafficLightGroupState(
+        actor_states={
+                "4411": TrafficLightState.green,
+                "3411": TrafficLightState.green,
+                "4399": TrafficLightState.red,
+                "3399": TrafficLightState.red
+            },
+        sequence_number=3,
+        duration=10,
+        next_state=4)
+    assert traffic_light_state_machine.time_remaining == 10
+
+
+def test_tick_large_dt_wraps_around_to_earlier_state(traffic_light_state_machine: TrafficLightStateMachine):
+    traffic_light_state_machine.set_to(0, 10)
+    traffic_light_state_machine.tick(45)
+    assert traffic_light_state_machine.current_state == TrafficLightGroupState(
+        actor_states={
+                "4411": TrafficLightState.red,
+                "3411": TrafficLightState.red,
+                "4399": TrafficLightState.red,
+                "3399": TrafficLightState.red
+            },
+        sequence_number=0,
+        duration=10,
+        next_state=1)
+    assert traffic_light_state_machine.time_remaining == 5
+
+
 def test_get_current_actor_states(traffic_light_state_machine: TrafficLightStateMachine):
     traffic_light_state_machine.set_to(4, 3)
     actor_states = traffic_light_state_machine.get_current_actor_states()

--- a/torchdrivesim/traffic_lights.py
+++ b/torchdrivesim/traffic_lights.py
@@ -125,7 +125,16 @@ class TrafficLightStateMachine:
         while self._time_remaining <= 0:
             next_state = self._current_state.next_state
             next_duration = self._states[next_state].duration
-            self.set_to(next_state, next_duration)
+            if self._time_remaining == 0:
+                self.set_to(next_state, next_duration)
+                break
+            elif self._time_remaining + next_duration > 0:
+                self._time_remaining += next_duration
+                self.set_to(next_state, self._time_remaining)
+                break
+            else:
+                self._time_remaining += next_duration
+                self._current_state = self._states[next_state]
 
     @property
     def states(self) -> List[TrafficLightGroupState]:


### PR DESCRIPTION
Making similar changes to an earlier bug fix on the API side:

- [x] Light state machine takes a large dt that spans multiple states, works properly now
- [x] Added test coverage for various dt values