### PR TITLE
Trim mesh before CV2 rendering

### DIFF
--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -112,6 +112,21 @@ class Cameras:
 
         return points
 
+    def reverse_transform_points_screen(self, points: Tensor, res: Resolution) -> Tensor:
+        rot_mat = torch.stack([
+            self.sc.flip(dims=[-1]),
+            self.sc * torch.tensor([-1, 1], device=points.device)
+        ], dim=-2)
+
+        # the operations below could be fused for efficiency
+        points = points - torch.tensor([res.width, res.height], device=points.device) / 2
+        points = points / (min(res.height, res.width) / 2)
+        points = - points / self.scale
+        points = torch.matmul(rot_mat.transpose(-1, -2), points.unsqueeze(-1)).squeeze(-1)
+        points = points + self.xy
+
+        return points
+
 
 class BirdviewRenderer(abc.ABC):
     """

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -26,9 +26,6 @@ class CV2Renderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
 
-        image_batch = []
-        pixel_verts = cameras.transform_points_screen(mesh.verts, res=res).cpu().to(torch.int32)
-
         if self.cfg.trim_mesh_before_rendering:
             # For efficiency, remove faces that are not visible anyway
             viewing_polygon = cameras.reverse_transform_points_screen(
@@ -37,7 +34,10 @@ class CV2Renderer(BirdviewRenderer):
                 ], device=mesh.device), res=res
             )
             viewing_polygon = viewing_polygon * 1.05  # safety margin
-            mesh = mesh.trim(viewing_polygon, trim_face_only=True)
+            mesh = mesh.trim(viewing_polygon)
+
+        image_batch = []
+        pixel_verts = cameras.transform_points_screen(mesh.verts, res=res).cpu().to(torch.int32)
 
         for k in mesh.categories:
             if k not in mesh.colors:

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -33,7 +33,8 @@ class CV2Renderer(BirdviewRenderer):
                     [0, 0], [0, res.height], [res.width, res.height], [res.width, 0]
                 ], device=mesh.device), res=res
             )
-            viewing_polygon = viewing_polygon * 1.05  # safety margin
+            viewing_polygon_center = viewing_polygon.mean(dim=-2)
+            viewing_polygon = viewing_polygon_center + (viewing_polygon - viewing_polygon_center) * 1.05  # safety margin
             mesh = mesh.trim(viewing_polygon)
 
         image_batch = []


### PR DESCRIPTION
This produces a substantial speedup, proportionally to the map size. In Town03 it seems to be about 5x using the standard field of view, but pytorch3d is still a few times faster. I checked if trimming the mesh helped there, but it didn't matter in my experiments.