### PR TITLE
Lower log threshold of lanelet errros in orientation loss to DEBUG

### DIFF
--- a/torchdrivesim/infractions.py
+++ b/torchdrivesim/infractions.py
@@ -288,7 +288,7 @@ def lanelet_orientation_loss(lanelet_maps: List[Optional[LaneletMap]], agents_st
                 else:
                     loss = torch.tensor(0.0).to(device)
             except LaneletError:
-                logger.error(
+                logger.debug(
                     "Lanelet errors occurred during computing the orientation losses."
                     " Setting the wrong way loss for the agent to be zero.")
                 loss = torch.tensor(0.0).to(device)


### PR DESCRIPTION
I don't think it's all that useful and it's just polluting my logs. If it's easy to do, we could consider warning once per map or something, but I'm not really sure it's worth it.