### PR TITLE
Set default value 0 for unused time argument of WaypointGoal.step

### DIFF
--- a/torchdrivesim/goals.py
+++ b/torchdrivesim/goals.py
@@ -152,7 +152,7 @@ class WaypointGoal:
             self.state = self.state[idx]
         return self
 
-    def step(self, agent_states: TensorPerAgentType, time: int, threshold = 2.0) -> None:
+    def step(self, agent_states: TensorPerAgentType, time: int = 0, threshold: float = 2.0) -> None:
         """
         Advances the state of the waypoints.
         """


### PR DESCRIPTION
Since it's not used, there's no point making it required. I would remove it, but that's not backwards compatible.