### PR TITLE
Let updated present mask overwrite no reentry mask

### DIFF
--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -2143,7 +2143,7 @@ class NoReentryBoundedRegionWrapper(BoundedRegionWrapper):
 
     def update_present_mask(self, present_mask):
         self.inner_simulator.update_present_mask(present_mask)
-        self.previous_present_mask = self.agent_functor(torch.logical_and, present_mask, self.previous_present_mask)
+        self.previous_present_mask = present_mask
 
     def get_present_mask(self):
         present_mask = super().get_present_mask()

--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -2139,7 +2139,9 @@ class NoReentryBoundedRegionWrapper(BoundedRegionWrapper):
         self.proximal_timesteps = self.across_agent_types(
             lambda x, y: x.mul(y), self.proximal_timesteps, self.previous_present_mask
         )
-        self.update_present_mask(self.get_present_mask())
+        present_mask = self.get_present_mask()
+        self.inner_simulator.update_present_mask(present_mask)
+        self.previous_present_mask = self.agent_functor(torch.logical_and, present_mask, self.previous_present_mask)
 
     def update_present_mask(self, present_mask):
         self.inner_simulator.update_present_mask(present_mask)


### PR DESCRIPTION
I think it should be this way, otherwise it's not possible to set the present mask for agents not currently present.