### PR TITLE
update README with portal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ such replay is not reactive, often resulting in spurious collisions.
 
 For maximum realism and reactivity, we recommend using our (Inverted AI) API for generating realistic behaviors,
 which is integrated with TorchDriveSim. This is a paid offering that requires an API key, which you can obtain by
-contacting us. For academics, we may be able to offer free API keys.
+creating an account [here](https://www.inverted.ai/portal/login). Academic researchers receive free credits when
+they sign up with their institution email.
 
 ## Maps and Map Formats
 


### PR DESCRIPTION
The current docs contain outdated info on how to obtain an API key, and should be updated to point to our portal. 

sidenote: its not immediately obvious to me in the documentation where the API key needs to be ingested, should the docs be updated to include that information?