### PR TITLE
Defaults to shift mesh by camera before rendering

### DIFF
--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -150,12 +150,16 @@ class BaseMesh:
         f = lambda x: x[idx]
         return dataclasses.replace(self, verts=f(self.verts), faces=f(self.faces))
     
-    def shift_by_camera(self, cameras: 'Cameras', inplace: bool = True) -> Self:
+    def translate(self, xy: torch.Tensor, inplace: bool = True) -> Self:
         """
-        Shifts the mesh by the camera position so that the camera is at the origin (0,0).
+        Shifts the mesh by the given coordinate so that it is at the origin (0,0).
+
+        Args:
+            xy: Bx2 tensor specifying the camera position
+            inplace: whether to modify the mesh in place
         """
         shifted_mesh = self if inplace else self.clone()
-        shifted_mesh.verts[..., :2] -= cameras.xy.unsqueeze(1)
+        shifted_mesh.verts[..., :2] -= xy.unsqueeze(1)
         return shifted_mesh
 
     def __getitem__(self, item):  # square bracket syntax for batch element selection

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -149,6 +149,14 @@ class BaseMesh:
         """
         f = lambda x: x[idx]
         return dataclasses.replace(self, verts=f(self.verts), faces=f(self.faces))
+    
+    def shift_by_camera(self, cameras: 'Cameras', inplace: bool = True) -> Self:
+        """
+        Shifts the mesh by the camera position so that the camera is at the origin (0,0).
+        """
+        shifted_mesh = self if inplace else self.clone()
+        shifted_mesh.verts[..., :2] -= cameras.xy.unsqueeze(1)
+        return shifted_mesh
 
     def __getitem__(self, item):  # square bracket syntax for batch element selection
         return self.select_batch_elements(item)

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -160,7 +160,7 @@ class BaseMesh:
         """
         shifted_mesh = self if inplace else self.clone()
         shifted_mesh.verts = shifted_mesh.verts.clone()
-        shifted_mesh.verts[..., :2] -= xy.unsqueeze(1)
+        shifted_mesh.verts[..., :2] += xy.unsqueeze(1)
         return shifted_mesh
 
     def __getitem__(self, item):  # square bracket syntax for batch element selection

--- a/torchdrivesim/mesh.py
+++ b/torchdrivesim/mesh.py
@@ -159,6 +159,7 @@ class BaseMesh:
             inplace: whether to modify the mesh in place
         """
         shifted_mesh = self if inplace else self.clone()
+        shifted_mesh.verts = shifted_mesh.verts.clone()
         shifted_mesh.verts[..., :2] -= xy.unsqueeze(1)
         return shifted_mesh
 

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -470,7 +470,7 @@ class BirdviewRenderer(abc.ABC):
         return image
 
     @abc.abstractmethod
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras)\
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True)\
             -> Tensor:
         """
         Renders a given mesh, producing BxHxWxC tensor image of float RGB values in [0,255] range.

--- a/torchdrivesim/rendering/base.py
+++ b/torchdrivesim/rendering/base.py
@@ -30,6 +30,7 @@ class RendererConfig:
     render_agent_direction: bool = True
     left_handed_coordinates: bool = False
     highlight_ego_vehicle: bool = False
+    shift_mesh_by_camera_before_rendering: bool = True
 
 
 @dataclass
@@ -470,7 +471,7 @@ class BirdviewRenderer(abc.ABC):
         return image
 
     @abc.abstractmethod
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True)\
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras)\
             -> Tensor:
         """
         Renders a given mesh, producing BxHxWxC tensor image of float RGB values in [0,255] range.

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -24,8 +24,9 @@ class CV2Renderer(BirdviewRenderer):
         super().__init__(cfg, *args, **kwargs)
         self.cfg: CV2RendererConfig = cfg
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
-
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
+        if shift_by_camera:
+            mesh = mesh.shift_by_camera(cameras)
         if self.cfg.trim_mesh_before_rendering:
             # For efficiency, remove faces that are not visible anyway
             viewing_polygon = cameras.reverse_transform_points_screen(

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -26,7 +26,7 @@ class CV2Renderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
         if shift_by_camera:
-            mesh = mesh.shift_by_camera(cameras)
+            mesh = mesh.translate(cameras.xy)
         if self.cfg.trim_mesh_before_rendering:
             # For efficiency, remove faces that are not visible anyway
             viewing_polygon = cameras.reverse_transform_points_screen(

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -27,6 +27,7 @@ class CV2Renderer(BirdviewRenderer):
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
         if shift_by_camera:
             mesh = mesh.translate(cameras.xy)
+            cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         if self.cfg.trim_mesh_before_rendering:
             # For efficiency, remove faces that are not visible anyway
             viewing_polygon = cameras.reverse_transform_points_screen(

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -26,7 +26,7 @@ class CV2Renderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
         if self.cfg.shift_mesh_by_camera_before_rendering:
-            mesh = mesh.translate(cameras.xy)
+            mesh = mesh.translate(-cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         if self.cfg.trim_mesh_before_rendering:
             # For efficiency, remove faces that are not visible anyway

--- a/torchdrivesim/rendering/cv2.py
+++ b/torchdrivesim/rendering/cv2.py
@@ -24,8 +24,8 @@ class CV2Renderer(BirdviewRenderer):
         super().__init__(cfg, *args, **kwargs)
         self.cfg: CV2RendererConfig = cfg
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
-        if shift_by_camera:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+        if self.cfg.shift_mesh_by_camera_before_rendering:
             mesh = mesh.translate(cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         if self.cfg.trim_mesh_before_rendering:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -79,8 +79,8 @@ class NvdiffrastRenderer(BirdviewRenderer):
         if self.glctx is None:
             raise RuntimeError('Failed to obtain glctx session for nvdiffrast')
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
-        if shift_by_camera:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+        if self.cfg.shift_mesh_by_camera_before_rendering:
             mesh = mesh.translate(cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         for k in mesh.categories:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -82,6 +82,7 @@ class NvdiffrastRenderer(BirdviewRenderer):
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
         if shift_by_camera:
             mesh = mesh.translate(cameras.xy)
+            cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -79,7 +79,9 @@ class NvdiffrastRenderer(BirdviewRenderer):
         if self.glctx is None:
             raise RuntimeError('Failed to obtain glctx session for nvdiffrast')
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
+        if shift_by_camera:
+            mesh = mesh.shift_by_camera(cameras)
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -81,7 +81,7 @@ class NvdiffrastRenderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
         if self.cfg.shift_mesh_by_camera_before_rendering:
-            mesh = mesh.translate(cameras.xy)
+            mesh = mesh.translate(-cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
         for k in mesh.categories:
             if k not in mesh.colors:

--- a/torchdrivesim/rendering/nvdiffrast.py
+++ b/torchdrivesim/rendering/nvdiffrast.py
@@ -81,7 +81,7 @@ class NvdiffrastRenderer(BirdviewRenderer):
 
     def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
         if shift_by_camera:
-            mesh = mesh.shift_by_camera(cameras)
+            mesh = mesh.translate(cameras.xy)
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -95,7 +95,7 @@ class Pytorch3DRenderer(BirdviewRenderer):
         if self.cfg.highlight_ego_vehicle:
             mesh.colors["ego"] = tensor_color((self.color_map["ego"]))
         if self.cfg.shift_mesh_by_camera_before_rendering:
-            mesh = mesh.translate(cameras.xy)
+            mesh = mesh.translate(-cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
 
         meshes = mesh.pytorch3d()

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -95,7 +95,7 @@ class Pytorch3DRenderer(BirdviewRenderer):
         if self.cfg.highlight_ego_vehicle:
             mesh.colors["ego"] = tensor_color((self.color_map["ego"]))
         if shift_by_camera:
-            mesh = mesh.shift_by_camera(cameras)
+            mesh = mesh.translate(cameras.xy)
         meshes = mesh.pytorch3d()
         if res != self.res:
             renderer = self.make_renderer(res, self.cfg.differentiable_rendering,

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -86,7 +86,7 @@ class Pytorch3DRenderer(BirdviewRenderer):
             background_color=tuple([x / 255.0 for x in self.get_color('background')])
         )
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])
@@ -94,6 +94,8 @@ class Pytorch3DRenderer(BirdviewRenderer):
                 mesh.zs[k] = self.rendering_levels[k]
         if self.cfg.highlight_ego_vehicle:
             mesh.colors["ego"] = tensor_color((self.color_map["ego"]))
+        if shift_by_camera:
+            mesh = mesh.shift_by_camera(cameras)
         meshes = mesh.pytorch3d()
         if res != self.res:
             renderer = self.make_renderer(res, self.cfg.differentiable_rendering,

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -86,7 +86,7 @@ class Pytorch3DRenderer(BirdviewRenderer):
             background_color=tuple([x / 255.0 for x in self.get_color('background')])
         )
 
-    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras, shift_by_camera: bool = True) -> torch.Tensor:
+    def render_mesh(self, mesh: BirdviewMesh, res: Resolution, cameras: Cameras) -> torch.Tensor:
         for k in mesh.categories:
             if k not in mesh.colors:
                 mesh.colors[k] = tensor_color(self.color_map[k])
@@ -94,7 +94,7 @@ class Pytorch3DRenderer(BirdviewRenderer):
                 mesh.zs[k] = self.rendering_levels[k]
         if self.cfg.highlight_ego_vehicle:
             mesh.colors["ego"] = tensor_color((self.color_map["ego"]))
-        if shift_by_camera:
+        if self.cfg.shift_mesh_by_camera_before_rendering:
             mesh = mesh.translate(cameras.xy)
             cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
 

--- a/torchdrivesim/rendering/pytorch3d.py
+++ b/torchdrivesim/rendering/pytorch3d.py
@@ -96,6 +96,8 @@ class Pytorch3DRenderer(BirdviewRenderer):
             mesh.colors["ego"] = tensor_color((self.color_map["ego"]))
         if shift_by_camera:
             mesh = mesh.translate(cameras.xy)
+            cameras = Cameras(xy=torch.zeros_like(cameras.xy), sc=cameras.sc, scale=cameras.scale)
+
         meshes = mesh.pytorch3d()
         if res != self.res:
             renderer = self.make_renderer(res, self.cfg.differentiable_rendering,


### PR DESCRIPTION
This will shift mesh at batch dimension by the center of the camera .
I tested by running the simulate examples with all 3 different renderers.