### PR TITLE
Pass Simulator to advance_npcs

### DIFF
--- a/torchdrivesim/behavior/replay.py
+++ b/torchdrivesim/behavior/replay.py
@@ -8,7 +8,7 @@ import torch
 from torch import Tensor
 
 from torchdrivesim.behavior.common import InitializationFailedError
-from torchdrivesim.simulator import NPCWrapper, SimulatorInterface, NPCController
+from torchdrivesim.simulator import NPCWrapper, SimulatorInterface, NPCController, Simulator
 from torchdrivesim.utils import assert_equal
 
 
@@ -159,8 +159,7 @@ class ReplayController(NPCController):
             self.npc_present_masks = torch.ones_like(self.npc_states[..., 0], dtype=torch.bool)
         super().__init__(npc_size, self.npc_states[..., self.time, :], self.npc_present_masks[..., self.time], npc_types, agent_type_names)
 
-    def advance_npcs(self, agent_size: Tensor, agent_state: Tensor, agent_present_mask: Optional[Tensor],
-                     agent_types: Optional[Tensor]) -> None:
+    def advance_npcs(self, simulator: Simulator) -> None:
         self.time += 1
         if self.time == self.npc_states.shape[-2]:
             self.time = 0

--- a/torchdrivesim/simulator.py
+++ b/torchdrivesim/simulator.py
@@ -528,8 +528,7 @@ class NPCController:
     def get_npc_present_mask(self):
         return self.npc_present_mask
 
-    def advance_npcs(self, agent_size: Tensor, agent_state: Tensor, agent_present_mask: Optional[Tensor],
-                     agent_types: Optional[Tensor]) -> None:
+    def advance_npcs(self, simulator: "Simulator") -> None:
         return None
 
     def to(self, device):
@@ -876,7 +875,7 @@ class Simulator(SimulatorInterface):
         # validate agent numbers
         assert_equal(agent_action.shape[-2], self.agent_count)
 
-        self.npc_controller.advance_npcs(self.agent_size, self.get_state(), self.get_present_mask(), self.get_agent_type())
+        self.npc_controller.advance_npcs(self)
         self.kinematic_model.step(agent_action)
 
         if self.traffic_controls is not None:


### PR DESCRIPTION
The existing interface is rather limiting, so instead I pass the full Simulator object to allow the NPC controller maximum freedom to use any information therein to update the NPC state. It does not affect the existing replay controller, since that doesn't use any of the inputs anyway.