### PR TITLE
Address readthedoc deprecation error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.8"
 
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
   install:
       - requirements: requirements/docs.txt


### PR DESCRIPTION
Readthedoc recently made a change that broke the documentation pipeline, this pr fixed it 