### PR TITLE
Send tensor to correct device in tests

### DIFF
--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -49,7 +49,7 @@ class TestBaseSimulator:
     @classmethod
     def setup_class(cls):
         cls.get_shapes(cls.data_batch_size)
-        cls.mock_agent_attributes = torch.ones(cls.data_batch_size, cls.mock_agent_count, 3)
+        cls.mock_agent_attributes = torch.ones(cls.data_batch_size, cls.mock_agent_count, 3).to(device)
         cls.mock_agent_state = torch.Tensor([[[0, 0, 0, 0], [1, 1, 0, 0]]]).expand(cls.data_batch_size, -1, -1).to(device)
         cls.mock_future_state = torch.Tensor([[[1, 1, 1, 0], [2, 2, 1, 0]]]).expand(cls.data_batch_size, -1, -1).to(device)
         cls.mock_action = torch.Tensor([[[0, 0], [1, 1]]]).expand(cls.data_batch_size, -1, -1).to(device)

--- a/tests/simulator/test_wrapped_simulators.py
+++ b/tests/simulator/test_wrapped_simulators.py
@@ -198,7 +198,7 @@ class TestIAIWrapper:
                             locations=[location])
 
     def test_step(self):
-        mock_action = torch.ones(1, 4, 2)
+        mock_action = torch.ones(1, 4, 2).to(device)
         self.simulator.step(mock_action)
     
     def test_get_state(self):


### PR DESCRIPTION
The GPU tests are failing on current master, but I guess we haven't caught it because we don't routinely run them. Good news is that it's the tests that are broken, not the code in the package.