### PR TITLE
Leon fix examples

### DIFF
--- a/examples/gym_env.py
+++ b/examples/gym_env.py
@@ -90,7 +90,7 @@ class GymEnv(gym.Env):
         # Capture frame if recording
         if self.recording:
             frame = self.simulator.render_egocentric(res=self.res, fov=self.fov)
-            self.frames.append(frame[0].cpu().numpy().transpose(1, 2, 0))
+            self.frames.append(frame[0][0].cpu().numpy().transpose(1, 2, 0)) # frame is BxAxCxHxW so we pick the 1st batch (of 1 total) and 1st agent (of 1 total)
             
         return self.get_obs(), self.get_reward(), self.is_done(), self.get_info()
 
@@ -182,6 +182,7 @@ class IAIGymEnv(GymEnv):
         kinematic_model = KinematicBicycle()
         kinematic_model.set_params(lr=ego_attributes[..., 2])
         kinematic_model.set_state(ego_states)
+        kinematic_model.to(device=device)
         renderer = renderer_from_config(simulator_cfg.renderer)
 
         # Create NPC controller

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -324,7 +324,7 @@ def rl_trainer(cfg: TorchDriveGymEnvConfig):
     env_gen = lambda: gym.make('torchdrivesim/IAI-v0', args=cfg)
     policy_trainer = PPOTrainer(env_gen)
     print('Training Reinforcement Learning Agent:')
-    progress_bar = trange(5, leave=True)
+    progress_bar = trange(100, leave=True)
     for i in progress_bar:
         policy_trainer.train_step()
         progress_bar.set_description(f"Average Return: {policy_trainer.evaluate_policy().item():.2f}")

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -4,7 +4,7 @@ Note that the behavior of other agents are provided by the IAI API, which requir
 However, it is easy to modify the environment to provide alternative means of controlling other agents.
 """
 import torch.nn as nn
-from .gym_env import *
+from gym_env import *
 import warnings
 from tqdm import trange
 warnings.filterwarnings("ignore")
@@ -324,7 +324,7 @@ def rl_trainer(cfg: TorchDriveGymEnvConfig):
     env_gen = lambda: gym.make('torchdrivesim/IAI-v0', args=cfg)
     policy_trainer = PPOTrainer(env_gen)
     print('Training Reinforcement Learning Agent:')
-    progress_bar = trange(100, leave=True)
+    progress_bar = trange(5, leave=True)
     for i in progress_bar:
         policy_trainer.train_step()
         progress_bar.set_description(f"Average Return: {policy_trainer.evaluate_policy().item():.2f}")

--- a/examples/simulate.py
+++ b/examples/simulate.py
@@ -67,6 +67,7 @@ def simulate(cfg: SimulationConfig):
     kinematic_model = KinematicBicycle()
     kinematic_model.set_params(lr=ego_attributes[..., 2])
     kinematic_model.set_state(ego_states)
+    kinematic_model.to(device=device)
     renderer = renderer_from_config(simulator_cfg.renderer)
     traffic_controls = traffic_controls_from_map_config(map_cfg)
     traffic_controls = {k: v.to(device) for k, v in traffic_controls.items()}


### PR DESCRIPTION
Fixed some examples which were failing to run.

- In `gym_env.py` and `simulate.py`, there were issues with `kinematic_model._normalization_factor` being on the cpu rather than being on the specified device, which threw an error when it was multiplied with a tensor on gpu.
- In `gym_env.py`, after changes in #98 and #99, we switched from using `BirdviewRecordingWrapper` to using `Simulator` class to render our frames. Originally `BirdviewRecordingWrapper` was meant to render only one camera, whereas `Simulator` can allow rendering from multiple cameras, which lead to `frames` tensor having an extra agent dimension (BxAxCxHxW as opposed to BxCxHxW from before). Changed `frame[0]` to `frame[0][0]` to accommodate this.
- in `rl_example.py`, we import from `.gym_env` which looks locally in the `examples/` folder. This appears to be a mistake, so I've reverted it to the original `gym_env`