### PR TITLE
feat: cache generated road and lane meshes

### DIFF
--- a/torchdrivesim/map.py
+++ b/torchdrivesim/map.py
@@ -3,6 +3,7 @@ import json
 import os
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict, List
+from functools import cached_property
 
 import lanelet2
 import numpy as np
@@ -14,10 +15,6 @@ from torchdrivesim.mesh import BirdviewMesh
 from torchdrivesim.traffic_controls import BaseTrafficControl, TrafficLightControl, StopSignControl, YieldControl
 from torchdrivesim.traffic_lights import TrafficLightController
 from torchdrivesim.utils import normalize_angle
-from functools import cached_property
-import logging
-import time
-logger = logging.getLogger(__name__)
 
 @dataclass
 class Stopline:

--- a/torchdrivesim/map.py
+++ b/torchdrivesim/map.py
@@ -14,7 +14,10 @@ from torchdrivesim.mesh import BirdviewMesh
 from torchdrivesim.traffic_controls import BaseTrafficControl, TrafficLightControl, StopSignControl, YieldControl
 from torchdrivesim.traffic_lights import TrafficLightController
 from torchdrivesim.utils import normalize_angle
-
+from functools import cached_property
+import logging
+import time
+logger = logging.getLogger(__name__)
 
 @dataclass
 class Stopline:
@@ -59,7 +62,7 @@ class MapConfig:
             return None
         return load_lanelet_map(self.lanelet_path, origin=self.lanelet_map_origin)
 
-    @property
+    @cached_property
     def road_mesh(self) -> Optional[BirdviewMesh]:
         if self.mesh_path is None:
             if self.lanelet_path is None:


### PR DESCRIPTION
When a mesh file is missing, road and lanelet meshes are generated on the fly from the lanelet map file. Previously, within the same request (i.e. /drive) these meshes were recalculated every time they were accessed, leading to redundant computations.